### PR TITLE
fix: capture worker token usage from stream-json output

### DIFF
--- a/agent-observability/tests/collection/server.test.ts
+++ b/agent-observability/tests/collection/server.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import type { Server } from 'node:http'
 import { createCollectionServer, createLocalhostOAuthProvider } from '../../src/collection/server.js'
+import { orgs as orgsTable } from '../../src/db/schema.js'
 
 const mockOrg = { id: 'org-1', slug: 'acme', name: 'Acme', createdAt: new Date() }
 const mockDeveloper = { id: 'dev-1', orgId: 'org-1', email: 'alice@example.com', name: 'Alice', createdAt: new Date() }
@@ -14,9 +15,14 @@ function makeMockDb(orgFound = true, developerFound = false) {
       }),
     }),
     update: () => ({ set: () => ({ where: () => ({ returning: async () => [mockSession] }) }) }),
+    // Differentiate org vs developer queries by the table passed to .from()
     select: () => ({
-      from: () => ({
-        where: async () => (developerFound ? [mockDeveloper] : []),
+      from: (table: unknown) => ({
+        where: async () => {
+          if (table === orgsTable) return orgFound ? [mockOrg] : []
+          // developer table query
+          return developerFound ? [mockDeveloper] : []
+        },
       }),
     }),
     query: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,8 +2,8 @@
 import { startCoordServer } from './server/index.js'
 import { startWebServer } from './web/server.js'
 import { startTui } from './tui/index.js'
-import { spawnWorker, writeWorkerMcpConfig } from './spawner/index.js'
-import { getTask } from './server/state/tasks.js'
+import { spawnWorker, writeWorkerMcpConfig, workerLogPath } from './spawner/index.js'
+import { getTask, updateTask } from './server/state/tasks.js'
 import { updateAgent } from './server/state/agents.js'
 import { writeFileSync, readFileSync, mkdirSync, rmSync, existsSync } from 'fs'
 import { join } from 'path'
@@ -17,6 +17,24 @@ interface AgentRow {
   cwd: string | null
   pid: number | null
   status: string
+}
+
+function parseTokensFromLog(logPath: string): { input_tokens?: number; output_tokens?: number; total_tokens?: number } {
+  try {
+    const lines = readFileSync(logPath, 'utf8').trim().split('\n').reverse()
+    for (const line of lines) {
+      try {
+        const msg = JSON.parse(line)
+        if (msg.type === 'result' && msg.usage) {
+          const input_tokens: number | undefined = msg.usage.input_tokens
+          const output_tokens: number | undefined = msg.usage.output_tokens
+          const total_tokens = (input_tokens ?? 0) + (output_tokens ?? 0) || undefined
+          return { input_tokens, output_tokens, total_tokens }
+        }
+      } catch { /* not JSON */ }
+    }
+  } catch { /* file not found or unreadable */ }
+  return {}
 }
 
 function startSpawnerWatcher(db: Database.Database, mcpConfigPath: string): void {
@@ -69,6 +87,13 @@ function startSpawnerWatcher(db: Database.Database, mcpConfigPath: string): void
         ).get(agent.id) as { status: string } | undefined
         if (current?.status === 'running' || current?.status === 'spawning') {
           updateAgent(db, agent.id, { status: 'failed' })
+        }
+        // Parse token usage from the worker log and store it on the task
+        if (agent.task_id) {
+          const tokens = parseTokensFromLog(workerLogPath(agent.id))
+          if (tokens.total_tokens !== undefined) {
+            updateTask(db, agent.task_id, tokens)
+          }
         }
       })
     }

--- a/src/spawner/index.ts
+++ b/src/spawner/index.ts
@@ -52,6 +52,9 @@ export function buildWorkerArgs(cfg: SpawnConfig): string[] {
   return [
     '--mcp-config', cfg.mcpConfigPath,
     '--dangerously-skip-permissions',
+    '--print',
+    '--verbose',
+    '--output-format', 'stream-json',
     prompt,
   ]
 }

--- a/tests/spawner/index.test.ts
+++ b/tests/spawner/index.test.ts
@@ -26,6 +26,21 @@ describe('spawner', () => {
     expect(args).toContain('/tmp/mc-worker-config.json')
   })
 
+  it('buildWorkerArgs includes --print --verbose --output-format stream-json for token tracking', () => {
+    const cfg: SpawnConfig = {
+      taskId: 'task-1',
+      taskTitle: 'Build JWT auth',
+      agentId: 'w-task-1',
+      worktreePath: '/tmp/mc-task-1',
+      mcpConfigPath: '/tmp/mc-worker-config.json',
+    }
+    const args = buildWorkerArgs(cfg)
+    expect(args).toContain('--print')
+    expect(args).toContain('--verbose')
+    expect(args).toContain('--output-format')
+    expect(args[args.indexOf('--output-format') + 1]).toBe('stream-json')
+  })
+
   it('buildWorkerArgs prompt includes task title', () => {
     const cfg: SpawnConfig = {
       taskId: 'task-1',


### PR DESCRIPTION
## Summary

- Spawn workers with `--print --verbose --output-format stream-json` so the Claude CLI writes NDJSON to the worker log file
- On process exit, parse the log file backwards to find the `{"type":"result","usage":{...}}` message and extract `input_tokens` / `output_tokens`
- Store token counts on the task via `updateTask`, making the TOKENS column in the TUI populate correctly

## Root cause

The `report_done` MCP tool accepted token params, but workers had no way to self-report token usage — the worker prompt only said `call report_done(task_id, summary)`. The fix reads token counts from the Claude CLI's own output after the process exits.

**Flag requirements discovered during implementation:**
- `--output-format stream-json` requires `--print` (explicit, not just positional-prompt print mode)
- `--output-format stream-json` also requires `--verbose`

## Test plan
- [x] Run `npm test` — spawner tests verify `--print`, `--verbose`, `--output-format stream-json` are present in worker args
- [x] Start multiclaude, run a task, confirm the TOKENS column shows actual values instead of `--`