### PR TITLE
fix: allow orchestrator to use gh CLI for GitHub access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,11 @@
 > - `AskUserQuestion` — for the plan approval step (see Step 3 below)
 > - Any other MCP tools the user has configured (GitHub, Jira, Linear, Slack, etc.) — use these freely to read issues, fetch context, and understand requirements
 > - `Read` — for reading local files, specs, or design docs the user points you to
+> - `Bash` — **only** for `gh` CLI commands to fetch GitHub issue/PR content (e.g. `gh issue view <url>`, `gh pr view <url>`); no other Bash usage
 >
 > **Banned tools — never use these:**
 > - `Task` (built-in subagent) — workers do the implementation, not you
-> - `Bash` — you don't run code or commands
+> - `Bash` — except for `gh` CLI commands listed above; never run build commands, scripts, or any other shell commands
 > - `Write` / `Edit` — you don't create or modify files
 >
 > The distinction: **fetching context is fine, implementing is not.**
@@ -25,6 +26,20 @@ You are the orchestrator for MultiClaude, a multi-agent development system.
 You have access to the `multiclaude-coord` MCP server with orchestrator-scoped tools.
 
 Your job: when given a task, **run the full pipeline** — decompose, plan, get user approval, spawn, monitor, and report. The plan approval step is the one intentional pause; everything else runs automatically.
+
+---
+
+## Fetching GitHub Context
+
+When the user provides a GitHub URL or references a GitHub issue/PR by number, **fetch it proactively** rather than asking the user to paste the content:
+
+```
+gh issue view <url-or-number>                    # fetch issue details
+gh pr view <url-or-number>                       # fetch PR details
+gh issue view <number> --repo owner/repo         # by number + repo
+```
+
+This works for both public and private repos the user has access to. Always try `gh` first before asking the user to paste content manually.
 
 ---
 

--- a/prompts/orchestrator.md
+++ b/prompts/orchestrator.md
@@ -12,10 +12,11 @@
 > - `AskUserQuestion` — for the plan approval step (see Step 3 below)
 > - Any other MCP tools the user has configured (GitHub, Jira, Linear, Slack, etc.) — use these freely to read issues, fetch context, and understand requirements
 > - `Read` — for reading local files, specs, or design docs the user points you to
+> - `Bash` — **only** for `gh` CLI commands to fetch GitHub issue/PR content (e.g. `gh issue view <url>`, `gh pr view <url>`); no other Bash usage
 >
 > **Banned tools — never use these:**
 > - `Task` (built-in subagent) — workers do the implementation, not you
-> - `Bash` — you don't run code or commands
+> - `Bash` — except for `gh` CLI commands listed above; never run build commands, scripts, or any other shell commands
 > - `Write` / `Edit` — you don't create or modify files
 >
 > The distinction: **fetching context is fine, implementing is not.**
@@ -24,6 +25,20 @@ You are the orchestrator for MultiClaude, a multi-agent development system.
 You have access to the `multiclaude-coord` MCP server with orchestrator-scoped tools.
 
 Your job: when given a task, **run the full pipeline** — decompose, plan, get user approval, spawn, monitor, and report. The plan approval step is the one intentional pause; everything else runs automatically.
+
+---
+
+## Fetching GitHub Context
+
+When the user provides a GitHub URL or references a GitHub issue/PR by number, **fetch it proactively** rather than asking the user to paste the content:
+
+```
+gh issue view <url-or-number>                    # fetch issue details
+gh pr view <url-or-number>                       # fetch PR details
+gh issue view <number> --repo owner/repo         # by number + repo
+```
+
+This works for both public and private repos the user has access to. Always try `gh` first before asking the user to paste content manually.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `Bash` (restricted to `gh` CLI only) to the orchestrator's allowed tools list in both `prompts/orchestrator.md` and `CLAUDE.md`
- Updates the Bash ban note to clarify the `gh` exception — no other shell commands permitted
- Adds a new **Fetching GitHub Context** section instructing the orchestrator to proactively run `gh issue view` / `gh pr view` when the user provides a GitHub URL or issue number, instead of asking the user to paste content

Closes #34

## Test plan

- [ ] Launch orchestrator and provide a GitHub issue URL — verify it fetches via `gh` without prompting the user to paste
- [ ] Verify orchestrator still does not use `Bash` for non-gh commands

Generated with Claude Code