### PR TITLE
fix: auto-allow all multiclaude-coord tools in orchestrator MCP config (#47)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -232,7 +232,10 @@ async function main() {
   const mcpTools = [
     'mcp__multiclaude-coord__cancel_task',
     'mcp__multiclaude-coord__complete_task',
+    'mcp__multiclaude-coord__create_run',
     'mcp__multiclaude-coord__get_system_status',
+    'mcp__multiclaude-coord__list_projects',
+    'mcp__multiclaude-coord__list_runs',
     'mcp__multiclaude-coord__plan_dag',
     'mcp__multiclaude-coord__spawn_worker',
     'mcp__multiclaude-coord__wait_for_event',
@@ -275,7 +278,10 @@ async function main() {
   const cursorCoordTools = [
     'mcp__multiclaude-coord__cancel_task',
     'mcp__multiclaude-coord__complete_task',
+    'mcp__multiclaude-coord__create_run',
     'mcp__multiclaude-coord__get_system_status',
+    'mcp__multiclaude-coord__list_projects',
+    'mcp__multiclaude-coord__list_runs',
     'mcp__multiclaude-coord__plan_dag',
     'mcp__multiclaude-coord__spawn_worker',
     'mcp__multiclaude-coord__wait_for_event',


### PR DESCRIPTION
## Summary
- Updates the orchestrator MCP config template to auto-approve all `multiclaude-coord` tools without prompting
- Closes #47

## Tasks included
- **i47-allow-create-run**: Auto-allows `plan_dag`, `spawn_worker`, `complete_task`, `cancel_task`, `create_run`, `list_runs`, `list_projects`, `wait_for_event`, `get_system_status` in `~/.claude/multiclaude-orchestrator-mcp.json`

## Test plan
- [ ] Start the coord server and verify the orchestrator MCP config is written with all tools auto-approved
- [ ] Launch an orchestrator session and confirm no permission prompts appear for any coord tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)