### PR TITLE
feat: per-task model selection with --model flag and DB storage (#55)

### DIFF
--- a/src/server/tools/orchestrator.ts
+++ b/src/server/tools/orchestrator.ts
@@ -11,6 +11,7 @@ export interface EpicTask {
   id: string
   title: string
   description?: string
+  model?: string
   dependsOn: string[]
 }
 
@@ -39,7 +40,7 @@ export function handlePlanDag(
     run_id = run.id
   }
   for (const t of epic.tasks) {
-    createTask(db, { id: t.id, title: t.title, description: t.description, run_id })
+    createTask(db, { id: t.id, title: t.title, description: t.description, model: t.model, run_id })
   }
   for (const t of epic.tasks) {
     for (const dep of t.dependsOn) {


### PR DESCRIPTION
## Tasks included
- **i55-model-db-spawner**: Added `model` field to `plan_dag` task schema, stored in DB (`tasks.model TEXT DEFAULT 'sonnet'`), returned in `get_my_task`, and passed as `--model <modelId>` to the `claude` CLI when spawning workers
- **i55-model-tui**: TUI now shows model tier badges ([haiku] in green, [opus] in purple) in the AGENT column

Closes #55