### PR TITLE
feat: add MODEL column with color-coded badges to web UI (#55)

### DIFF
--- a/src/web/public/run.html
+++ b/src/web/public/run.html
@@ -31,6 +31,10 @@
     .badge.done { background: #14532d; color: #4ade80; }
     .badge.failed { background: #450a0a; color: #f87171; }
     .badge.cancelled { background: #1a1a1a; color: #555; }
+    .model-badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 11px; }
+    .model-badge.haiku { background: #14532d; color: #4ade80; }
+    .model-badge.sonnet { background: #1e1e5e; color: #7c83fd; }
+    .model-badge.opus { background: #3b0764; color: #c084fc; }
     .retry { color: #fbbf24; font-size: 11px; }
     .task-row { cursor: pointer; }
     .task-row:hover td { background: #1e1e3a; }
@@ -97,6 +101,7 @@
       <tr>
         <th>Task</th>
         <th>Status</th>
+        <th>Model</th>
         <th>Agent</th>
         <th>Retries</th>
         <th>Duration</th>
@@ -305,7 +310,7 @@
 
       const tbody = document.getElementById('tasks')
       if (tasks.length === 0) {
-        tbody.innerHTML = '<tr><td colspan="6" class="empty-state">No tasks in this run.</td></tr>'
+        tbody.innerHTML = '<tr><td colspan="7" class="empty-state">No tasks in this run.</td></tr>'
         return
       }
 
@@ -319,17 +324,20 @@
         const tokHtml = t.total_tokens
           ? `<span class="tokens">${formatTokens(t.total_tokens)}</span><div class="token-detail">${formatTokens(t.input_tokens)}↑ ${formatTokens(t.output_tokens)}↓</div>`
           : '-'
+        const modelKey = (t.model || '').toLowerCase().includes('haiku') ? 'haiku' : (t.model || '').toLowerCase().includes('opus') ? 'opus' : 'sonnet'
+        const modelHtml = t.model ? `<span class="model-badge ${modelKey}">${escapeHtml(modelKey)}</span>` : '-'
         return `
           <tr class="task-row" onclick="togglePanel('${escapeHtml(t.id)}')">
             <td>${escapeHtml(t.title)}${hint}</td>
             <td><span class="badge ${t.status}">${t.status.replace('_', ' ')}</span></td>
+            <td>${modelHtml}</td>
             <td>${escapeHtml(t.agent_id || '-')}</td>
             <td>${t.retry_count > 0 ? `<span class="retry">⚠ ${t.retry_count}/${t.max_retries}</span>` : '-'}</td>
             <td>${durHtml}</td>
             <td>${tokHtml}</td>
           </tr>
           <tr class="log-row" id="log-row-${escapeHtml(t.id)}">
-            <td colspan="6">
+            <td colspan="7">
               <div class="log-panel ${isOpen ? 'open' : ''}" id="log-panel-${escapeHtml(t.id)}">
                 ${isOpen ? buildLogPanelSkeleton(t.id) : ''}
               </div>

--- a/src/web/public/tasks.html
+++ b/src/web/public/tasks.html
@@ -30,6 +30,10 @@
     .badge.done { background: #14532d; color: #4ade80; }
     .badge.failed { background: #450a0a; color: #f87171; }
     .badge.cancelled { background: #1a1a1a; color: #555; }
+    .model-badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 11px; }
+    .model-badge.haiku { background: #14532d; color: #4ade80; }
+    .model-badge.sonnet { background: #1e1e5e; color: #7c83fd; }
+    .model-badge.opus { background: #3b0764; color: #c084fc; }
     .retry { color: #fbbf24; font-size: 11px; }
     /* Log panel */
     .task-row { cursor: pointer; }
@@ -80,6 +84,7 @@
       <tr>
         <th>Task</th>
         <th>Status</th>
+        <th>Model</th>
         <th>Agent</th>
         <th>Retries</th>
         <th>Duration</th>
@@ -203,17 +208,20 @@
         const tokHtml = t.total_tokens
           ? `<span class="tokens">${formatTokens(t.total_tokens)}</span><div class="token-detail">${formatTokens(t.input_tokens)}↑ ${formatTokens(t.output_tokens)}↓</div>`
           : '-'
+        const modelKey = (t.model || '').toLowerCase().includes('haiku') ? 'haiku' : (t.model || '').toLowerCase().includes('opus') ? 'opus' : 'sonnet'
+        const modelHtml = t.model ? `<span class="model-badge ${modelKey}">${escapeHtml(modelKey)}</span>` : '-'
         return `
           <tr class="task-row" onclick="togglePanel('${escapeHtml(t.id)}')">
             <td>${escapeHtml(t.title)}${hint}</td>
             <td><span class="badge ${t.status}">${t.status.replace('_', ' ')}</span></td>
+            <td>${modelHtml}</td>
             <td>${escapeHtml(t.agent_id || '-')}</td>
             <td>${t.retry_count > 0 ? `<span class="retry">⚠ ${t.retry_count}/${t.max_retries}</span>` : '-'}</td>
             <td>${durHtml}</td>
             <td>${tokHtml}</td>
           </tr>
           <tr class="log-row" id="log-row-${escapeHtml(t.id)}">
-            <td colspan="6">
+            <td colspan="7">
               <div class="log-panel ${isOpen ? 'open' : ''}" id="log-panel-${escapeHtml(t.id)}">
                 ${isOpen ? buildLogPanelSkeleton(t.id, agentLogPaths) : ''}
               </div>


### PR DESCRIPTION
## Tasks included
- **i55-model-web**: Added MODEL column to run.html and tasks.html with color-coded badges (haiku=green, sonnet=blue, opus=purple)

Part of #55