### PR TITLE
feat: add ticket field to tasks for multi-ticket grouping

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -102,6 +102,7 @@ function createOrchestratorMcp(db: Database.Database): McpServer {
           title: z.string(),
           description: z.string().optional(),
           model: z.enum(['haiku', 'sonnet', 'opus']).optional().describe('Model to use for this task (default: sonnet)'),
+          ticket: z.string().optional().describe('Optional ticket/issue reference (e.g. GitHub URL or issue number)'),
           dependsOn: z.array(z.string()),
         })),
         run_id: z.string().optional(),

--- a/src/server/state/db.ts
+++ b/src/server/state/db.ts
@@ -41,6 +41,7 @@ export function createDb(path: string = './multiclaude.db'): Database.Database {
       repo_path TEXT,
       cost_usd REAL,
       run_id TEXT REFERENCES runs(id),
+      ticket TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
@@ -80,6 +81,7 @@ export function createDb(path: string = './multiclaude.db'): Database.Database {
   try { db.exec("ALTER TABLE tasks ADD COLUMN model TEXT NOT NULL DEFAULT 'sonnet'") } catch { /* already exists */ }
   try { db.exec("ALTER TABLE tasks ADD COLUMN repo_path TEXT") } catch { /* already exists */ }
   try { db.exec("ALTER TABLE tasks ADD COLUMN cost_usd REAL") } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE tasks ADD COLUMN ticket TEXT") } catch { /* already exists */ }
   try { db.exec("ALTER TABLE runs ADD COLUMN budget_usd REAL") } catch { /* already exists */ }
   return db
 }

--- a/src/server/state/tasks.ts
+++ b/src/server/state/tasks.ts
@@ -21,6 +21,7 @@ export interface Task {
   total_tokens: number | null
   cost_usd: number | null
   run_id: string | null
+  ticket: string | null
   created_at: string
   updated_at: string
 }
@@ -32,6 +33,7 @@ export interface CreateTaskInput {
   model?: string
   max_retries?: number
   run_id?: string
+  ticket?: string
 }
 
 export interface UpdateTaskInput {
@@ -51,8 +53,8 @@ export interface UpdateTaskInput {
 
 export function createTask(db: Database.Database, input: CreateTaskInput): void {
   db.prepare(`
-    INSERT INTO tasks (id, title, description, model, max_retries, run_id)
-    VALUES (@id, @title, @description, @model, @max_retries, @run_id)
+    INSERT INTO tasks (id, title, description, model, max_retries, run_id, ticket)
+    VALUES (@id, @title, @description, @model, @max_retries, @run_id, @ticket)
   `).run({
     id: input.id,
     title: input.title,
@@ -60,6 +62,7 @@ export function createTask(db: Database.Database, input: CreateTaskInput): void 
     model: input.model ?? 'sonnet',
     max_retries: input.max_retries ?? 3,
     run_id: input.run_id ?? null,
+    ticket: input.ticket ?? null,
   })
 }
 

--- a/src/server/tools/orchestrator.ts
+++ b/src/server/tools/orchestrator.ts
@@ -12,6 +12,7 @@ export interface EpicTask {
   title: string
   description?: string
   model?: string
+  ticket?: string
   dependsOn: string[]
 }
 
@@ -39,7 +40,7 @@ export function handlePlanDag(
     run_id = run.id
   }
   for (const t of epic.tasks) {
-    createTask(db, { id: t.id, title: t.title, description: t.description, model: t.model, run_id })
+    createTask(db, { id: t.id, title: t.title, description: t.description, model: t.model, run_id, ticket: t.ticket })
   }
   for (const t of epic.tasks) {
     for (const dep of t.dependsOn) {


### PR DESCRIPTION
## Summary
- Adds `ticket TEXT` column to tasks table via `ALTER TABLE` migration in `db.ts`
- Updates `Task` and `CreateTaskInput` interfaces in `tasks.ts` to include optional `ticket` field
- Updates `handlePlanDag` in `orchestrator.ts` to accept and persist `ticket` per task

Part of run: **feat: multi-ticket single-run with ticket grouping**