### PR TITLE
tmux worker backend — attachable worker sessions

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -146,6 +146,9 @@ function startSpawnerWatcher(
       if (handle.pid !== undefined) {
         updateAgent(db, agent.id, { pid: handle.pid })
       }
+      if (handle.tmuxPane !== undefined) {
+        updateAgent(db, agent.id, { tmux_pane: handle.tmuxPane })
+      }
 
       if (openTerminals) {
         openWorkerTerminal(agent.id, workerLogPath(agent.id))

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,8 +2,9 @@
 import { startCoordServer } from './server/index.js'
 import { startWebServer } from './web/server.js'
 import { startTui } from './tui/index.js'
-import { spawnWorker, writeWorkerMcpConfig, workerLogPath } from './spawner/index.js'
-import { spawnCursorWorker } from './spawner/cursor.js'
+import { writeWorkerMcpConfig, workerLogPath } from './spawner/index.js'
+import { createBackend } from './spawner/backend.js'
+import type { RuntimeBackend } from './spawner/backend.js'
 import { openWorkerTerminal } from './spawner/terminal.js'
 import { getTask, updateTask, listTasks } from './server/state/tasks.js'
 import { updateAgent } from './server/state/agents.js'
@@ -46,8 +47,7 @@ function parseTokensFromLog(logPath: string): { input_tokens?: number; output_to
 function startSpawnerWatcher(
   db: Database.Database,
   mcpConfigPath: string,
-  workerRuntime: WorkerRuntime = 'claude',
-  serverPort: number = 7432,
+  backend: RuntimeBackend,
   openTerminals: boolean = false,
   stuckWarningMinutes: number = 10,
   stuckTimeoutMinutes: number = 30,
@@ -133,75 +133,43 @@ function startSpawnerWatcher(
         openTerminals,
       }
 
-      if (workerRuntime === 'cursor') {
-        // Cursor worker: uses node-pty, writes its own .cursor/mcp.json
-        let ptyProcess
-        try {
-          ptyProcess = spawnCursorWorker({ ...spawnCfg, serverPort })
-        } catch (err: unknown) {
-          const msg = err instanceof Error ? err.message : String(err)
-          console.error(`[spawner] Failed to launch Cursor worker ${agent.id}: ${msg}`)
-          updateAgent(db, agent.id, { status: 'failed' })
-          continue
-        }
-
-        updateAgent(db, agent.id, { pid: ptyProcess.pid })
-
-        if (openTerminals) {
-          openWorkerTerminal(agent.id, workerLogPath(agent.id))
-        }
-
-        ptyProcess.onExit(() => {
-          // If worker exited without calling report_done, mark agent as failed
-          const current = db.prepare(
-            "SELECT status FROM agents WHERE id = ?"
-          ).get(agent.id) as { status: string } | undefined
-          if (current?.status === 'running' || current?.status === 'spawning') {
-            updateAgent(db, agent.id, { status: 'failed' })
-          }
-          if (agent.task_id) {
-            const tokens = parseTokensFromLog(workerLogPath(agent.id))
-            if (tokens.total_tokens !== undefined) {
-              updateTask(db, agent.task_id, tokens)
-            }
-          }
-        })
-      } else {
-        // Claude worker: uses ChildProcess with --mcp-config
-        const child = spawnWorker(spawnCfg)
-
-        if (child.pid !== undefined) {
-          updateAgent(db, agent.id, { pid: child.pid })
-        }
-
-        if (openTerminals) {
-          openWorkerTerminal(agent.id, workerLogPath(agent.id))
-        }
-
-        child.on('error', (err) => {
-          // spawn failed (e.g. 'claude' binary not found) — mark agent failed so
-          // the orchestrator can retry instead of waiting forever
-          console.error(`[spawner] Failed to launch worker ${agent.id}: ${err.message}`)
-          updateAgent(db, agent.id, { status: 'failed' })
-        })
-
-        child.on('exit', () => {
-          // If worker exited without calling report_done, mark agent as failed
-          const current = db.prepare(
-            "SELECT status FROM agents WHERE id = ?"
-          ).get(agent.id) as { status: string } | undefined
-          if (current?.status === 'running' || current?.status === 'spawning') {
-            updateAgent(db, agent.id, { status: 'failed' })
-          }
-          // Parse token usage from the worker log and store it on the task
-          if (agent.task_id) {
-            const tokens = parseTokensFromLog(workerLogPath(agent.id))
-            if (tokens.total_tokens !== undefined) {
-              updateTask(db, agent.task_id, tokens)
-            }
-          }
-        })
+      let handle
+      try {
+        handle = backend.launch(spawnCfg)
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err)
+        console.error(`[spawner] Failed to launch worker ${agent.id}: ${msg}`)
+        updateAgent(db, agent.id, { status: 'failed' })
+        continue
       }
+
+      if (handle.pid !== undefined) {
+        updateAgent(db, agent.id, { pid: handle.pid })
+      }
+
+      if (openTerminals) {
+        openWorkerTerminal(agent.id, workerLogPath(agent.id))
+      }
+
+      handle.onError((err) => {
+        console.error(`[spawner] Failed to launch worker ${agent.id}: ${err.message}`)
+        updateAgent(db, agent.id, { status: 'failed' })
+      })
+
+      handle.onExit(() => {
+        const current = db.prepare(
+          "SELECT status FROM agents WHERE id = ?"
+        ).get(agent.id) as { status: string } | undefined
+        if (current?.status === 'running' || current?.status === 'spawning') {
+          updateAgent(db, agent.id, { status: 'failed' })
+        }
+        if (agent.task_id) {
+          const tokens = parseTokensFromLog(workerLogPath(agent.id))
+          if (tokens.total_tokens !== undefined) {
+            updateTask(db, agent.task_id, tokens)
+          }
+        }
+      })
     }
   }, 1000)
 
@@ -242,8 +210,9 @@ async function main() {
   const workerRuntimeFlag = workerRuntimeArg
     ? (workerRuntimeArg.split('=')[1] as WorkerRuntime)
     : null
-  if (workerRuntimeFlag && workerRuntimeFlag !== 'claude' && workerRuntimeFlag !== 'cursor') {
-    console.error(`Error: --worker-runtime must be "claude" or "cursor", got "${workerRuntimeFlag}"`)
+  const validRuntimes: WorkerRuntime[] = ['claude', 'cursor', 'tmux']
+  if (workerRuntimeFlag && !validRuntimes.includes(workerRuntimeFlag)) {
+    console.error(`Error: --worker-runtime must be one of ${validRuntimes.map(r => `"${r}"`).join(', ')}, got "${workerRuntimeFlag}"`)
     process.exit(1)
   }
 
@@ -269,8 +238,9 @@ async function main() {
   const mcpConfigPath = writeWorkerMcpConfig(port)
 
   // Start watcher: polls DB for spawning agents and launches worker subprocesses
+  const backend = createBackend(effectiveRuntime, { serverPort: port })
   startSpawnerWatcher(
-    db, mcpConfigPath, effectiveRuntime, port, openTerminals,
+    db, mcpConfigPath, backend, openTerminals,
     multiclaudeConfig?.stuckWarningMinutes ?? 10,
     multiclaudeConfig?.stuckTimeoutMinutes ?? 30,
   )

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, existsSync } from 'fs'
 import { join } from 'path'
 
-export type WorkerRuntime = 'claude' | 'cursor'
+export type WorkerRuntime = 'claude' | 'cursor' | 'tmux'
 
 export interface MultiClaudeConfig {
   workerRuntime: WorkerRuntime

--- a/src/server/state/agents.ts
+++ b/src/server/state/agents.ts
@@ -8,6 +8,7 @@ export interface Agent {
   pid: number | null
   status: AgentStatus
   cwd: string | null
+  tmux_pane: string | null
   created_at: string
 }
 
@@ -24,12 +25,13 @@ export function getAgent(db: Database.Database, id: string): Agent | null {
   return (db.prepare('SELECT * FROM agents WHERE id = ?').get(id) as Agent | undefined) ?? null
 }
 
-export function updateAgent(db: Database.Database, id: string, input: { status?: AgentStatus; pid?: number; cwd?: string }): void {
+export function updateAgent(db: Database.Database, id: string, input: { status?: AgentStatus; pid?: number; cwd?: string; tmux_pane?: string }): void {
   const sets: string[] = []
   const params: Record<string, unknown> = { id }
   if (input.status !== undefined) { sets.push('status = @status'); params.status = input.status }
   if (input.pid !== undefined) { sets.push('pid = @pid'); params.pid = input.pid }
   if (input.cwd !== undefined) { sets.push('cwd = @cwd'); params.cwd = input.cwd }
+  if (input.tmux_pane !== undefined) { sets.push('tmux_pane = @tmux_pane'); params.tmux_pane = input.tmux_pane }
   if (sets.length === 0) return
   db.prepare(`UPDATE agents SET ${sets.join(', ')} WHERE id = @id`).run(params)
 }

--- a/src/server/state/db.ts
+++ b/src/server/state/db.ts
@@ -72,6 +72,7 @@ export function createDb(path: string = './multiclaude.db'): Database.Database {
   `)
   // Migrations: add columns that may be missing in older DBs
   try { db.exec("ALTER TABLE agents ADD COLUMN cwd TEXT") } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE agents ADD COLUMN tmux_pane TEXT") } catch { /* already exists */ }
   try { db.exec("ALTER TABLE tasks ADD COLUMN started_at TEXT") } catch { /* already exists */ }
   try { db.exec("ALTER TABLE tasks ADD COLUMN duration_seconds REAL") } catch { /* already exists */ }
   try { db.exec("ALTER TABLE tasks ADD COLUMN input_tokens INTEGER") } catch { /* already exists */ }

--- a/src/spawner/backend.ts
+++ b/src/spawner/backend.ts
@@ -6,6 +6,7 @@ import type { WorkerRuntime } from '../config.js'
 
 export interface WorkerHandle {
   pid: number | undefined
+  tmuxPane?: string
   onExit(callback: () => void): void
   onError(callback: (err: Error) => void): void
 }

--- a/src/spawner/backend.ts
+++ b/src/spawner/backend.ts
@@ -1,6 +1,7 @@
 import type { SpawnConfig } from './index.js'
 import { spawnWorker } from './index.js'
 import { spawnCursorWorker } from './cursor.js'
+import { spawnTmuxWorker } from './tmux.js'
 import type { WorkerRuntime } from '../config.js'
 
 export interface WorkerHandle {
@@ -41,6 +42,12 @@ export class CursorBackend implements RuntimeBackend {
   }
 }
 
+export class TmuxBackend implements RuntimeBackend {
+  launch(cfg: SpawnConfig): WorkerHandle {
+    return spawnTmuxWorker(cfg)
+  }
+}
+
 export interface BackendOptions {
   serverPort?: number
 }
@@ -55,7 +62,7 @@ export function createBackend(runtime: WorkerRuntime, opts: BackendOptions = {})
       }
       return new CursorBackend({ serverPort: opts.serverPort })
     case 'tmux':
-      throw new Error('tmux runtime backend is not yet implemented')
+      return new TmuxBackend()
     default: {
       const _exhaustive: never = runtime
       throw new Error(`Unknown runtime: ${_exhaustive}`)

--- a/src/spawner/backend.ts
+++ b/src/spawner/backend.ts
@@ -1,0 +1,64 @@
+import type { SpawnConfig } from './index.js'
+import { spawnWorker } from './index.js'
+import { spawnCursorWorker } from './cursor.js'
+import type { WorkerRuntime } from '../config.js'
+
+export interface WorkerHandle {
+  pid: number | undefined
+  onExit(callback: () => void): void
+  onError(callback: (err: Error) => void): void
+}
+
+export interface RuntimeBackend {
+  launch(cfg: SpawnConfig): WorkerHandle
+}
+
+export class ProcessBackend implements RuntimeBackend {
+  launch(cfg: SpawnConfig): WorkerHandle {
+    const child = spawnWorker(cfg)
+    return {
+      pid: child.pid,
+      onExit(cb) { child.on('exit', cb) },
+      onError(cb) { child.on('error', cb) },
+    }
+  }
+}
+
+export class CursorBackend implements RuntimeBackend {
+  private serverPort: number
+
+  constructor(opts: { serverPort: number }) {
+    this.serverPort = opts.serverPort
+  }
+
+  launch(cfg: SpawnConfig): WorkerHandle {
+    const ptyProcess = spawnCursorWorker({ ...cfg, serverPort: this.serverPort })
+    return {
+      pid: ptyProcess.pid,
+      onExit(cb) { ptyProcess.onExit(cb) },
+      onError(_cb) { /* PTY spawn throws synchronously; no async error event */ },
+    }
+  }
+}
+
+export interface BackendOptions {
+  serverPort?: number
+}
+
+export function createBackend(runtime: WorkerRuntime, opts: BackendOptions = {}): RuntimeBackend {
+  switch (runtime) {
+    case 'claude':
+      return new ProcessBackend()
+    case 'cursor':
+      if (opts.serverPort === undefined) {
+        throw new Error('CursorBackend requires serverPort in options')
+      }
+      return new CursorBackend({ serverPort: opts.serverPort })
+    case 'tmux':
+      throw new Error('tmux runtime backend is not yet implemented')
+    default: {
+      const _exhaustive: never = runtime
+      throw new Error(`Unknown runtime: ${_exhaustive}`)
+    }
+  }
+}

--- a/src/spawner/stuck-watcher.ts
+++ b/src/spawner/stuck-watcher.ts
@@ -1,20 +1,45 @@
 import type Database from 'better-sqlite3'
 import { getTask, updateTask } from '../server/state/tasks.js'
 import { updateAgent } from '../server/state/agents.js'
+import { captureTmuxPane } from './tmux.js'
 
 interface RunningAgentRow {
   id: string
   task_id: string | null
   status: string
+  tmux_pane: string | null
+}
+
+const BUSY_PATTERNS = [
+  /esc to interrupt/i,
+  /working\.\.\./i,
+]
+
+/**
+ * Returns true if the captured pane text contains a Claude Code busy footer
+ * in the last ~6 non-blank lines, indicating the worker is mid-turn.
+ */
+export function isPaneBusy(paneText: string): boolean {
+  // Strip ANSI escape sequences before matching
+  const stripped = paneText.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '')
+  const lastLines = stripped
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l.length > 0)
+    .slice(-6)
+  return lastLines.some(line => BUSY_PATTERNS.some(p => p.test(line)))
 }
 
 /**
  * Check all running agents for stuck workers and take action:
+ * - If the agent has a tmux pane and it shows a busy footer, skip (worker is mid-turn)
  * - Warn (insert a log entry) if no log activity for >= stuckWarningMinutes
  * - Fail (mark task failed) if no log activity for >= stuckTimeoutMinutes
  *
  * `stuckSince` is an in-memory Map<taskId, timestamp> tracking the first time
  * we noticed a worker was stuck — callers must pass the same Map across calls.
+ *
+ * `capturePane` is injectable for testing; defaults to the real tmux capture.
  */
 export function checkStuckWorkers(
   db: Database.Database,
@@ -22,15 +47,26 @@ export function checkStuckWorkers(
   stuckWarningMinutes: number,
   stuckTimeoutMinutes: number,
   now: number = Date.now(),
+  capturePane: (target: string, lines: number) => string = captureTmuxPane,
 ): void {
   const runningAgents = db.prepare(
-    "SELECT id, task_id, status FROM agents WHERE status = 'running'"
+    "SELECT id, task_id, status, tmux_pane FROM agents WHERE status = 'running'"
   ).all() as RunningAgentRow[]
 
   for (const agent of runningAgents) {
     if (!agent.task_id) continue
     const task = getTask(db, agent.task_id)
     if (!task || task.status !== 'in_progress') continue
+
+    // If the worker has a visible tmux pane, check for a busy footer first.
+    // A busy pane means Claude is mid-turn — not stuck.
+    if (agent.tmux_pane) {
+      const paneText = capturePane(agent.tmux_pane, 6)
+      if (isPaneBusy(paneText)) {
+        stuckSince.delete(task.id)
+        continue
+      }
+    }
 
     // Most recent log entry for this task
     const logRow = db.prepare(

--- a/src/spawner/tmux.ts
+++ b/src/spawner/tmux.ts
@@ -82,6 +82,38 @@ export function sendTmuxKeys(target: string, command: string): void {
   execSync(`tmux send-keys -t ${shellQuote(target)} ${shellQuote(command)} Enter`, { stdio: 'pipe' })
 }
 
+export type ComposerState = 'empty' | 'pending' | 'unknown'
+
+/**
+ * Classifies the composer state from raw captured pane content.
+ *
+ * Returns:
+ * - 'unknown': pane shows a busy indicator (Claude is processing — can't tell composer state)
+ * - 'pending': submittedText is still visible in the cleaned composer area (not yet submitted)
+ * - 'empty': submittedText is gone (was submitted, or composer is idle)
+ *
+ * Handles four layout styles:
+ *   bordered      │ text │ — strips box-drawing before checking
+ *   ghost-text    SGR-2 dim placeholders — stripped before checking
+ *   busy-footer   "ESC to interrupt" indicator — returns 'unknown'
+ *   bare-prompt   plain "> " prompt with no decoration
+ */
+export function classifyComposerState(rawPane: string, submittedText: string): ComposerState {
+  // Busy-footer: Claude is actively processing; composer state is indeterminate
+  if (/ESC to interrupt/.test(rawPane)) {
+    return 'unknown'
+  }
+
+  // Clean: strip dim ghost text, box-drawing borders, remaining ANSI
+  const cleaned = cleanComposerLine(rawPane)
+
+  if (submittedText.length > 0 && cleaned.includes(submittedText)) {
+    return 'pending'
+  }
+
+  return 'empty'
+}
+
 /**
  * Strips dim/faint (SGR 2) regions from a string.
  * Removes everything from an SGR sequence containing attribute 2 (dim)

--- a/src/spawner/tmux.ts
+++ b/src/spawner/tmux.ts
@@ -68,6 +68,106 @@ export function sendTmuxKeys(target: string, command: string): void {
 }
 
 /**
+ * Strips dim/faint (SGR 2) regions from a string.
+ * Removes everything from an SGR sequence containing attribute 2 (dim)
+ * until the next SGR 22 (normal intensity) or SGR 0 (full reset).
+ */
+export function stripAnsiDim(s: string): string {
+  // Match SGR sequences that set dim (attribute 2 alone or in a list like 1;2)
+  // and remove everything until the closing SGR 22 or SGR 0, or end-of-string.
+  return s.replace(/\x1b\[(?:\d+;)*2(?:;\d+)*m(?:(?!\x1b\[(?:22|0)m)[\s\S])*(?:\x1b\[(?:22|0)m)?/g, '')
+}
+
+/**
+ * Strips box-drawing border characters: │ (U+2502), ┃ (U+2503), and ASCII |.
+ */
+export function stripBoxDrawing(s: string): string {
+  return s.replace(/[│┃|]/g, '')
+}
+
+/**
+ * Cleans a captured composer line: strips dim ghost text, box-drawing borders,
+ * all remaining ANSI escape sequences, and trims whitespace.
+ */
+export function cleanComposerLine(s: string): string {
+  let cleaned = stripAnsiDim(s)
+  cleaned = stripBoxDrawing(cleaned)
+  // Strip all remaining ANSI escape sequences
+  cleaned = cleaned.replace(/\x1b\[[0-9;]*m/g, '')
+  return cleaned.trim()
+}
+
+/**
+ * Captures the visible text of a tmux pane, including ANSI escape sequences.
+ * Returns the raw captured text, or empty string on failure.
+ */
+export function capturePaneText(target: string): string {
+  try {
+    return execSync(
+      `tmux capture-pane -e -p -t ${shellQuote(target)}`,
+      { encoding: 'utf8', stdio: 'pipe' }
+    ).trim()
+  } catch {
+    return ''
+  }
+}
+
+export interface SendToPaneOptions {
+  maxEnterRetries?: number
+  retryDelayMs?: number
+}
+
+export interface SendToPaneResult {
+  sent: boolean
+  enterRetries: number
+}
+
+/**
+ * Sends text to a tmux pane and verifies it was submitted.
+ *
+ * Types the text via send-keys, presses Enter, then uses capture-pane -e to
+ * read back the pane content. If the typed text is still visible in the
+ * composer (after stripping dim ghost text and box-drawing borders), retries
+ * pressing Enter — never retypes the text.
+ *
+ * This avoids two known failure modes:
+ *   1. Bordered-empty composer misread as "text pending" (box chars stripped)
+ *   2. Dim ghost/placeholder text misread as human input (SGR 2 stripped)
+ */
+export function sendToPane(
+  target: string,
+  text: string,
+  opts: SendToPaneOptions = {},
+): SendToPaneResult {
+  const maxRetries = opts.maxEnterRetries ?? 3
+  const retryDelay = opts.retryDelayMs ?? 100
+
+  // Type the text (without Enter)
+  execSync(`tmux send-keys -t ${shellQuote(target)} ${shellQuote(text)}`, { stdio: 'pipe' })
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    // Press Enter
+    execSync(`tmux send-keys -t ${shellQuote(target)} Enter`, { stdio: 'pipe' })
+
+    // Brief pause to let the pane process the keystroke
+    if (retryDelay > 0) {
+      execSync(`sleep ${retryDelay / 1000}`, { stdio: 'pipe' })
+    }
+
+    // Capture the pane and check if text is still in the composer
+    const raw = capturePaneText(target)
+    const cleaned = cleanComposerLine(raw)
+
+    // If the cleaned pane content no longer contains our text, it was submitted
+    if (!cleaned.includes(text)) {
+      return { sent: true, enterRetries: attempt }
+    }
+  }
+
+  return { sent: false, enterRetries: maxRetries }
+}
+
+/**
  * Writes a self-contained bash launch script for the worker into the worktree's
  * .claude directory. Returns the script path.
  *

--- a/src/spawner/tmux.ts
+++ b/src/spawner/tmux.ts
@@ -6,6 +6,21 @@ import type { SpawnConfig } from './index.js'
 import { buildWorkerArgs, buildWorkerEnv } from './index.js'
 import type { WorkerHandle } from './backend.js'
 
+/**
+ * Captures the last `lines` lines of a tmux pane using capture-pane.
+ * Returns empty string if tmux is unavailable or the target doesn't exist.
+ */
+export function captureTmuxPane(target: string, lines: number = 40): string {
+  try {
+    return execSync(
+      `tmux capture-pane -p -t ${shellQuote(target)} -S -${lines}`,
+      { encoding: 'utf8', stdio: 'pipe' }
+    )
+  } catch {
+    return ''
+  }
+}
+
 /** Single-quote a string for POSIX shell — handles embedded single quotes. */
 function shellQuote(s: string): string {
   return "'" + s.replace(/'/g, "'\\''") + "'"
@@ -138,6 +153,7 @@ export function spawnTmuxWorker(cfg: SpawnConfig): WorkerHandle {
 
   return {
     pid: panePid,
+    tmuxPane: windowTarget,
     onExit(cb) { monitor.on('exit', cb) },
     onError(cb) { monitor.on('error', cb) },
   }

--- a/src/spawner/tmux.ts
+++ b/src/spawner/tmux.ts
@@ -1,0 +1,144 @@
+import { execSync, spawn } from 'child_process'
+import { writeFileSync, mkdirSync } from 'fs'
+import { join } from 'path'
+
+import type { SpawnConfig } from './index.js'
+import { buildWorkerArgs, buildWorkerEnv } from './index.js'
+import type { WorkerHandle } from './backend.js'
+
+/** Single-quote a string for POSIX shell — handles embedded single quotes. */
+function shellQuote(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'"
+}
+
+/**
+ * Returns the tmux session to target.
+ * - If running inside tmux ($TMUX is set), returns the current session name.
+ * - Otherwise ensures a detached 'multiclaude' session exists and returns its name.
+ */
+export function ensureTmuxSession(): string {
+  if (process.env.TMUX) {
+    return execSync('tmux display-message -p "#{session_name}"', { encoding: 'utf8' }).trim()
+  }
+
+  const sessionName = 'multiclaude'
+  try {
+    execSync(`tmux has-session -t ${shellQuote(sessionName)}`, { stdio: 'pipe' })
+  } catch {
+    // Session does not exist — create it detached
+    execSync(`tmux new-session -d -s ${shellQuote(sessionName)}`, { stdio: 'pipe' })
+  }
+  return sessionName
+}
+
+/**
+ * Creates a tmux window named mc-<taskId> in the given session,
+ * rooted at worktreePath. Returns the window target (session:window).
+ */
+export function createTmuxWindow(sessionName: string, taskId: string, worktreePath: string): string {
+  const windowName = `mc-${taskId}`
+  execSync(
+    `tmux new-window -d -t ${shellQuote(sessionName)}: -n ${shellQuote(windowName)} -c ${shellQuote(worktreePath)}`,
+    { stdio: 'pipe' }
+  )
+  return `${sessionName}:${windowName}`
+}
+
+/**
+ * Returns the shell PID of the given tmux pane target, or undefined on failure.
+ */
+export function getTmuxPanePid(target: string): number | undefined {
+  try {
+    const raw = execSync(
+      `tmux display-message -t ${shellQuote(target)} -p '#{pane_pid}'`,
+      { encoding: 'utf8', stdio: 'pipe' }
+    ).trim()
+    const n = parseInt(raw, 10)
+    return Number.isFinite(n) ? n : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Sends a line of text to a tmux pane as keystrokes, followed by Enter.
+ */
+export function sendTmuxKeys(target: string, command: string): void {
+  execSync(`tmux send-keys -t ${shellQuote(target)} ${shellQuote(command)} Enter`, { stdio: 'pipe' })
+}
+
+/**
+ * Writes a self-contained bash launch script for the worker into the worktree's
+ * .claude directory. Returns the script path.
+ *
+ * Using a script file sidesteps shell-quoting the long prompt string inline in
+ * the send-keys command.
+ */
+export function writeLaunchScript(cfg: SpawnConfig): string {
+  const args = buildWorkerArgs({ ...cfg, openTerminals: true })
+  const env = buildWorkerEnv(cfg.agentId)
+
+  const lines: string[] = ['#!/usr/bin/env bash', 'set -e', '']
+  for (const [key, val] of Object.entries(env)) {
+    if (val !== undefined) {
+      lines.push(`export ${key}=${shellQuote(val)}`)
+    }
+  }
+  lines.push('')
+  lines.push(`exec claude ${args.map(shellQuote).join(' ')}`)
+  lines.push('')
+
+  const scriptPath = join(cfg.worktreePath, '.claude', 'worker-launch.sh')
+  writeFileSync(scriptPath, lines.join('\n'), { mode: 0o755 })
+  return scriptPath
+}
+
+/**
+ * Spawns a Claude worker inside a tmux window.
+ *
+ * Flow:
+ *   1. Ensure a tmux session (reuse $TMUX session, or create/reuse 'multiclaude')
+ *   2. Create a window named mc-<taskId> rooted at the worktree path
+ *   3. Write a launch script and send it to the pane via send-keys
+ *   4. Append `; tmux wait-for -S <signal>` so exit is detectable
+ *   5. Spawn a monitor child process running `tmux wait-for <signal>`
+ *      which unblocks when the pane's command finishes
+ *
+ * The agent runs inside the window and is attachable with `tmux attach`.
+ */
+export function spawnTmuxWorker(cfg: SpawnConfig): WorkerHandle {
+  const claudeDir = join(cfg.worktreePath, '.claude')
+  mkdirSync(claudeDir, { recursive: true })
+  writeFileSync(
+    join(claudeDir, 'settings.local.json'),
+    JSON.stringify({ permissions: { allow: [
+      'Bash(*)', 'Write(*)', 'Edit(*)', 'Read(*)',
+      'mcp__multiclaude-worker__get_my_task',
+      'mcp__multiclaude-worker__report_progress',
+      'mcp__multiclaude-worker__report_done',
+      'mcp__multiclaude-worker__report_blocked',
+    ] } }, null, 2)
+  )
+
+  const sessionName = ensureTmuxSession()
+  const windowTarget = createTmuxWindow(sessionName, cfg.taskId, cfg.worktreePath)
+  const panePid = getTmuxPanePid(windowTarget)
+
+  const scriptPath = writeLaunchScript(cfg)
+  const waitSignal = `mc-${cfg.taskId}-exit`
+
+  // Run the script; signal when done so the monitor below detects exit
+  sendTmuxKeys(windowTarget, `bash ${shellQuote(scriptPath)}; tmux wait-for -S ${shellQuote(waitSignal)}`)
+
+  // Monitor blocks until the signal fires (claude exits in the pane)
+  const monitor = spawn('tmux', ['wait-for', waitSignal], {
+    stdio: 'ignore',
+    detached: false,
+  })
+
+  return {
+    pid: panePid,
+    onExit(cb) { monitor.on('exit', cb) },
+    onError(cb) { monitor.on('error', cb) },
+  }
+}

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -3,8 +3,10 @@ import { render, Box, Text, useInput, useApp } from 'ink'
 import { exec } from 'child_process'
 import { listTasks } from '../server/state/tasks.js'
 import { listAgents } from '../server/state/agents.js'
+import type { Agent } from '../server/state/agents.js'
 import { listRuns } from '../server/state/runs.js'
 import { workerLogPath } from '../spawner/index.js'
+import { captureTmuxPane } from '../spawner/tmux.js'
 import { calculateCost } from '../server/cost.js'
 import type { Task } from '../server/state/tasks.js'
 import type Database from 'better-sqlite3'
@@ -91,11 +93,14 @@ function Dashboard({ db, refreshMs = 1000 }: DashboardProps) {
   const [tasks, setTasks] = useState<Task[]>([])
   const [latestLogs, setLatestLogs] = useState<Map<string, LatestLogRow>>(new Map())
   const [runTickets, setRunTickets] = useState<Map<string, string>>(new Map())
+  const [agentsByTaskId, setAgentsByTaskId] = useState<Map<string, Agent>>(new Map())
+  const [paneLines, setPaneLines] = useState<Map<string, string>>(new Map())
   const { exit } = useApp()
 
   useEffect(() => {
     const refresh = () => {
-      setTasks(listTasks(db))
+      const currentTasks = listTasks(db)
+      setTasks(currentTasks)
       const rows = db.prepare(LATEST_LOG_SQL).all() as LatestLogRow[]
       setLatestLogs(new Map(rows.map(r => [r.task_id, r])))
       const runs = listRuns(db)
@@ -104,6 +109,26 @@ function Dashboard({ db, refreshMs = 1000 }: DashboardProps) {
         if (run.external_ref) tickets.set(run.id, run.external_ref)
       }
       setRunTickets(tickets)
+
+      // Capture tmux pane content for running agents that have a pane target
+      const agents = listAgents(db)
+      const byTask = new Map<string, Agent>()
+      for (const a of agents) {
+        if (a.task_id) byTask.set(a.task_id, a)
+      }
+      setAgentsByTaskId(byTask)
+
+      const newPaneLines = new Map<string, string>()
+      for (const t of currentTasks) {
+        if (t.status !== 'in_progress') continue
+        const agent = byTask.get(t.id)
+        if (!agent?.tmux_pane) continue
+        const raw = captureTmuxPane(agent.tmux_pane, 5)
+        // Take the last non-empty line as the live status indicator
+        const lastLine = raw.split('\n').map(l => l.trimEnd()).filter(Boolean).pop() ?? ''
+        newPaneLines.set(t.id, lastLine)
+      }
+      setPaneLines(newPaneLines)
     }
     refresh()
     const interval = setInterval(refresh, refreshMs)
@@ -114,9 +139,6 @@ function Dashboard({ db, refreshMs = 1000 }: DashboardProps) {
     if (input === 'q') exit()
     if (input === 'w') openBrowser(WEB_DASHBOARD_URL)
   })
-
-  // suppress unused import warning
-  void listAgents
 
   const running = tasks.filter(t => t.status === 'in_progress').length
   const done = tasks.filter(t => t.status === 'done').length
@@ -190,7 +212,9 @@ function Dashboard({ db, refreshMs = 1000 }: DashboardProps) {
               </Box>
               {t.status === 'in_progress' && t.agent_id && (
                 <Box paddingLeft={3}>
-                  {logMsg ? (
+                  {paneLines.get(t.id) ? (
+                    <Text dimColor>↳ {paneLines.get(t.id)?.slice(0, 80)}</Text>
+                  ) : logMsg ? (
                     <Text dimColor>↳ {logMsg}{log?.created_at ? `  (last log ${formatTimeAgo(log.created_at)})` : ''}</Text>
                   ) : (
                     <Text dimColor>↳ tail -f {workerLogPath(t.agent_id)}</Text>

--- a/src/web/public/run.html
+++ b/src/web/public/run.html
@@ -61,6 +61,13 @@
     .log-entry.done-msg { color: #4ade80; }
     .log-panel .empty { color: #555; font-size: 12px; font-style: italic; }
     .expand-hint { color: #555; font-size: 11px; margin-left: 6px; }
+    .panel-tabs { display: flex; gap: 4px; margin-bottom: 8px; }
+    .panel-tab { padding: 2px 10px; border-radius: 10px; font-size: 11px; cursor: pointer; border: 1px solid #2a2a4e; color: #888; background: transparent; }
+    .panel-tab.active { background: #1e1e5e; color: #7c83fd; border-color: #7c83fd; }
+    .pane-content { max-height: 240px; overflow-y: auto; background: #0a0a18; border-radius: 4px; padding: 6px 8px; }
+    .pane-line { font-size: 11px; line-height: 1.5; color: #ccc; white-space: pre-wrap; word-break: break-all; }
+    .pane-target { font-size: 11px; color: #555; margin-bottom: 6px; }
+    .pane-target span { color: #7c83fd; }
     .tokens { color: #a78bfa; }
     .cost-val { color: #34d399; }
     .duration { color: #94a3b8; }
@@ -119,10 +126,15 @@
   </table>
   <script>
     const openPanels = new Set()
+    // 'logs' or 'pane' — default tab per task
+    const panelTab = new Map()
     // Map of taskId -> EventSource for live log streams
     const logStreams = new Map()
+    // Map of taskId -> interval for pane polling
+    const panePollers = new Map()
     let latestData = null
     let agentLogPaths = {}
+    let agentTmuxPanes = {}
     let dagEdges = []
     let runBudgetUsd = null
 
@@ -211,13 +223,71 @@
       }
     }
 
+    function getTaskAgentId(taskId) {
+      return latestData?.find(t => t.id === taskId)?.agent_id || null
+    }
+
     function buildLogPanelSkeleton(taskId) {
-      const agentId = latestData?.find(t => t.id === taskId)?.agent_id
+      const agentId = getTaskAgentId(taskId)
       const logPath = agentId ? agentLogPaths[agentId] : null
+      const tmuxPane = agentId ? agentTmuxPanes[agentId] : null
+      const activeTab = panelTab.get(taskId) || (tmuxPane ? 'pane' : 'logs')
+
+      const tabsHtml = tmuxPane
+        ? `<div class="panel-tabs">
+            <button class="panel-tab${activeTab === 'logs' ? ' active' : ''}" onclick="switchTab('${escapeHtml(taskId)}','logs')">LOGS</button>
+            <button class="panel-tab${activeTab === 'pane' ? ' active' : ''}" onclick="switchTab('${escapeHtml(taskId)}','pane')">PANE</button>
+          </div>`
+        : ''
+
+      if (activeTab === 'pane' && tmuxPane) {
+        const targetHtml = `<div class="pane-target">tmux: <span>${escapeHtml(tmuxPane)}</span></div>`
+        return `${tabsHtml}${targetHtml}<div class="pane-content" id="pane-content-${escapeHtml(taskId)}"><div class="empty">Loading pane…</div></div>`
+      }
+
       const pathHtml = logPath
         ? `<div class="log-path">Full output: <span>tail -f ${escapeHtml(logPath)}</span></div>`
         : ''
-      return `${pathHtml}<div class="log-entries"><div class="empty">Loading logs…</div></div>`
+      return `${tabsHtml}${pathHtml}<div class="log-entries"><div class="empty">Loading logs…</div></div>`
+    }
+
+    function startPanePoller(taskId) {
+      if (panePollers.has(taskId)) return
+      const agentId = getTaskAgentId(taskId)
+      if (!agentId) return
+
+      async function fetchPane() {
+        try {
+          const resp = await fetch(`/api/peek/${encodeURIComponent(agentId)}`)
+          if (!resp.ok) return
+          const { content } = await resp.json()
+          const el = document.getElementById(`pane-content-${taskId}`)
+          if (!el) return
+          const wasAtBottom = el.scrollHeight - el.scrollTop <= el.clientHeight + 4
+          const lines = (content || '').split('\n')
+          el.innerHTML = lines.map(l => `<div class="pane-line">${escapeHtml(l)}</div>`).join('')
+          if (wasAtBottom) el.scrollTop = el.scrollHeight
+        } catch {}
+      }
+
+      fetchPane()
+      panePollers.set(taskId, setInterval(fetchPane, 2000))
+    }
+
+    function stopPanePoller(taskId) {
+      const id = panePollers.get(taskId)
+      if (id) { clearInterval(id); panePollers.delete(taskId) }
+    }
+
+    function switchTab(taskId, tab) {
+      event.stopPropagation()
+      panelTab.set(taskId, tab)
+      if (tab === 'pane') {
+        stopLogStream(taskId)
+      } else {
+        stopPanePoller(taskId)
+      }
+      if (latestData) renderTasks(latestData)
     }
 
     function renderDag(tasks, edges) {
@@ -401,14 +471,20 @@
 
       tbody.innerHTML = rows
 
-      // Re-attach live streams for any open panels (DOM was rebuilt)
+      // Re-attach live streams/pollers for any open panels (DOM was rebuilt)
       for (const taskId of openPanels) {
-        const stream = logStreams.get(taskId)
-        if (stream) {
-          stream.close()
-          logStreams.delete(taskId)
+        const agentId = getTaskAgentId(taskId)
+        const tmuxPane = agentId ? agentTmuxPanes[agentId] : null
+        const activeTab = panelTab.get(taskId) || (tmuxPane ? 'pane' : 'logs')
+        if (activeTab === 'pane') {
+          stopLogStream(taskId)
+          startPanePoller(taskId)
+        } else {
+          stopPanePoller(taskId)
+          const stream = logStreams.get(taskId)
+          if (stream) { stream.close(); logStreams.delete(taskId) }
+          startLogStream(taskId)
         }
-        startLogStream(taskId)
       }
     }
 
@@ -417,6 +493,7 @@
       if (openPanels.has(taskId)) {
         openPanels.delete(taskId)
         stopLogStream(taskId)
+        stopPanePoller(taskId)
       } else {
         openPanels.add(taskId)
       }
@@ -492,6 +569,7 @@
     es.onmessage = ({ data }) => {
       const snapshot = JSON.parse(data)
       agentLogPaths = snapshot.agentLogPaths || {}
+      agentTmuxPanes = snapshot.agentTmuxPanes || {}
       const runTasks = snapshot.tasks || []
       // Skip task-table re-render if only logs changed (live streams handle that)
       if (JSON.stringify(latestData) !== JSON.stringify(runTasks)) {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -3,10 +3,11 @@ import { join } from 'path'
 import { fileURLToPath } from 'url'
 import type Database from 'better-sqlite3'
 import { listTasks } from '../server/state/tasks.js'
-import { listAgents } from '../server/state/agents.js'
+import { listAgents, getAgent } from '../server/state/agents.js'
 import { listProjects, getProject } from '../server/state/projects.js'
 import { listRunsWithStats, getRun } from '../server/state/runs.js'
 import { workerLogPath } from '../spawner/index.js'
+import { captureTmuxPane } from '../spawner/tmux.js'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
@@ -35,8 +36,10 @@ function getSnapshot(db: Database.Database) {
   }
   // Add log file paths for agents that have been spawned
   const agentLogPaths: Record<string, string> = {}
+  const agentTmuxPanes: Record<string, string> = {}
   for (const agent of agents) {
     agentLogPaths[agent.id] = workerLogPath(agent.id)
+    if (agent.tmux_pane) agentTmuxPanes[agent.id] = agent.tmux_pane
   }
   const projects = listProjects(db)
   return {
@@ -45,6 +48,7 @@ function getSnapshot(db: Database.Database) {
     edges: db.prepare('SELECT * FROM dag_edges').all(),
     logsByTask,
     agentLogPaths,
+    agentTmuxPanes,
     projects,
   }
 }
@@ -161,6 +165,18 @@ export function startWebServer(db: Database.Database, port = 3000): void {
     send()
     const interval = setInterval(send, 1000)
     req.on('close', () => clearInterval(interval))
+  })
+
+  // Pane capture: GET /api/peek/:agentId?lines=<n>
+  app.get('/api/peek/:agentId', (req, res) => {
+    const agent = getAgent(db, req.params['agentId'])
+    if (!agent?.tmux_pane) {
+      res.json({ pane: null, content: '' })
+      return
+    }
+    const lines = Math.min(parseInt((req.query['lines'] as string) || '40', 10), 200)
+    const content = captureTmuxPane(agent.tmux_pane, lines)
+    res.json({ pane: agent.tmux_pane, content })
   })
 
   // Page routes — serve HTML files from public/

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, rmSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { readConfig, writeConfig } from '../src/config.js'
+import type { WorkerRuntime } from '../src/config.js'
+
+let testDir: string
+
+beforeEach(() => {
+  testDir = join(tmpdir(), `mc-config-test-${Date.now()}`)
+  mkdirSync(testDir, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+describe('WorkerRuntime', () => {
+  it('accepts claude as a valid runtime', () => {
+    const runtime: WorkerRuntime = 'claude'
+    writeConfig(testDir, { workerRuntime: runtime })
+    const config = readConfig(testDir)
+    expect(config?.workerRuntime).toBe('claude')
+  })
+
+  it('accepts cursor as a valid runtime', () => {
+    const runtime: WorkerRuntime = 'cursor'
+    writeConfig(testDir, { workerRuntime: runtime })
+    const config = readConfig(testDir)
+    expect(config?.workerRuntime).toBe('cursor')
+  })
+
+  it('accepts tmux as a valid runtime', () => {
+    const runtime: WorkerRuntime = 'tmux'
+    writeConfig(testDir, { workerRuntime: runtime })
+    const config = readConfig(testDir)
+    expect(config?.workerRuntime).toBe('tmux')
+  })
+})
+
+describe('readConfig', () => {
+  it('returns null when .multiclaude.json does not exist', () => {
+    expect(readConfig(testDir)).toBeNull()
+  })
+
+  it('reads valid config', () => {
+    writeFileSync(
+      join(testDir, '.multiclaude.json'),
+      JSON.stringify({ workerRuntime: 'claude' })
+    )
+    const config = readConfig(testDir)
+    expect(config).toEqual({ workerRuntime: 'claude' })
+  })
+
+  it('returns null for malformed JSON', () => {
+    writeFileSync(join(testDir, '.multiclaude.json'), 'not json')
+    expect(readConfig(testDir)).toBeNull()
+  })
+})
+
+describe('writeConfig', () => {
+  it('writes .multiclaude.json with proper formatting', () => {
+    writeConfig(testDir, { workerRuntime: 'tmux' })
+    const raw = readFileSync(join(testDir, '.multiclaude.json'), 'utf-8')
+    const parsed = JSON.parse(raw)
+    expect(parsed.workerRuntime).toBe('tmux')
+    expect(raw.endsWith('\n')).toBe(true)
+  })
+})

--- a/tests/spawner/backend.test.ts
+++ b/tests/spawner/backend.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { createBackend, ProcessBackend, CursorBackend } from '../../src/spawner/backend.js'
+import type { RuntimeBackend, WorkerHandle } from '../../src/spawner/backend.js'
+
+describe('RuntimeBackend interface', () => {
+  it('ProcessBackend implements RuntimeBackend', () => {
+    const backend: RuntimeBackend = new ProcessBackend()
+    expect(backend).toBeInstanceOf(ProcessBackend)
+    expect(typeof backend.launch).toBe('function')
+  })
+
+  it('CursorBackend implements RuntimeBackend', () => {
+    const backend: RuntimeBackend = new CursorBackend({ serverPort: 7432 })
+    expect(backend).toBeInstanceOf(CursorBackend)
+    expect(typeof backend.launch).toBe('function')
+  })
+})
+
+describe('createBackend', () => {
+  it('returns ProcessBackend for claude runtime', () => {
+    const backend = createBackend('claude')
+    expect(backend).toBeInstanceOf(ProcessBackend)
+  })
+
+  it('returns CursorBackend for cursor runtime', () => {
+    const backend = createBackend('cursor', { serverPort: 7432 })
+    expect(backend).toBeInstanceOf(CursorBackend)
+  })
+
+  it('throws for tmux runtime (not yet implemented)', () => {
+    expect(() => createBackend('tmux')).toThrow(/not yet implemented/i)
+  })
+
+  it('throws for cursor runtime without serverPort', () => {
+    expect(() => createBackend('cursor')).toThrow(/serverPort/)
+  })
+})
+
+describe('WorkerHandle shape', () => {
+  it('has the expected interface members', () => {
+    const handle: WorkerHandle = {
+      pid: 123,
+      onExit: (_cb: () => void) => {},
+      onError: (_cb: (err: Error) => void) => {},
+    }
+    expect(handle.pid).toBe(123)
+    expect(typeof handle.onExit).toBe('function')
+    expect(typeof handle.onError).toBe('function')
+  })
+
+  it('pid can be undefined (spawn failure)', () => {
+    const handle: WorkerHandle = {
+      pid: undefined,
+      onExit: () => {},
+      onError: () => {},
+    }
+    expect(handle.pid).toBeUndefined()
+  })
+})

--- a/tests/spawner/backend.test.ts
+++ b/tests/spawner/backend.test.ts
@@ -7,9 +7,11 @@ import type { RuntimeBackend, WorkerHandle } from '../../src/spawner/backend.js'
 vi.mock('../../src/spawner/tmux.js', () => ({
   spawnTmuxWorker: vi.fn(() => ({
     pid: undefined,
+    tmuxPane: 'multiclaude:mc-task-1',
     onExit: vi.fn(),
     onError: vi.fn(),
   })),
+  captureTmuxPane: vi.fn(() => ''),
 }))
 
 describe('RuntimeBackend interface', () => {
@@ -63,6 +65,16 @@ describe('WorkerHandle shape', () => {
     expect(handle.pid).toBe(123)
     expect(typeof handle.onExit).toBe('function')
     expect(typeof handle.onError).toBe('function')
+  })
+
+  it('tmuxPane is optional and carries the window target', () => {
+    const handle: WorkerHandle = {
+      pid: undefined,
+      tmuxPane: 'multiclaude:mc-my-task',
+      onExit: () => {},
+      onError: () => {},
+    }
+    expect(handle.tmuxPane).toBe('multiclaude:mc-my-task')
   })
 
   it('pid can be undefined (spawn failure)', () => {

--- a/tests/spawner/backend.test.ts
+++ b/tests/spawner/backend.test.ts
@@ -1,6 +1,16 @@
-import { describe, it, expect } from 'vitest'
-import { createBackend, ProcessBackend, CursorBackend } from '../../src/spawner/backend.js'
+import { describe, it, expect, vi } from 'vitest'
+import { createBackend, ProcessBackend, CursorBackend, TmuxBackend } from '../../src/spawner/backend.js'
 import type { RuntimeBackend, WorkerHandle } from '../../src/spawner/backend.js'
+
+// TmuxBackend calls into child_process and fs at construction/launch time;
+// mock them so the import doesn't fail in CI where tmux is not installed.
+vi.mock('../../src/spawner/tmux.js', () => ({
+  spawnTmuxWorker: vi.fn(() => ({
+    pid: undefined,
+    onExit: vi.fn(),
+    onError: vi.fn(),
+  })),
+}))
 
 describe('RuntimeBackend interface', () => {
   it('ProcessBackend implements RuntimeBackend', () => {
@@ -12,6 +22,12 @@ describe('RuntimeBackend interface', () => {
   it('CursorBackend implements RuntimeBackend', () => {
     const backend: RuntimeBackend = new CursorBackend({ serverPort: 7432 })
     expect(backend).toBeInstanceOf(CursorBackend)
+    expect(typeof backend.launch).toBe('function')
+  })
+
+  it('TmuxBackend implements RuntimeBackend', () => {
+    const backend: RuntimeBackend = new TmuxBackend()
+    expect(backend).toBeInstanceOf(TmuxBackend)
     expect(typeof backend.launch).toBe('function')
   })
 })
@@ -27,8 +43,9 @@ describe('createBackend', () => {
     expect(backend).toBeInstanceOf(CursorBackend)
   })
 
-  it('throws for tmux runtime (not yet implemented)', () => {
-    expect(() => createBackend('tmux')).toThrow(/not yet implemented/i)
+  it('returns TmuxBackend for tmux runtime', () => {
+    const backend = createBackend('tmux')
+    expect(backend).toBeInstanceOf(TmuxBackend)
   })
 
   it('throws for cursor runtime without serverPort', () => {

--- a/tests/spawner/stuck-watcher.test.ts
+++ b/tests/spawner/stuck-watcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { createDb, closeDb } from '../../src/server/state/db.js'
-import { checkStuckWorkers } from '../../src/spawner/stuck-watcher.js'
+import { checkStuckWorkers, isPaneBusy } from '../../src/spawner/stuck-watcher.js'
 import type Database from 'better-sqlite3'
 
 const WARNING_MINUTES = 5
@@ -9,6 +9,51 @@ const TIMEOUT_MINUTES = 10
 function minutesAgo(minutes: number): string {
   return new Date(Date.now() - minutes * 60_000).toISOString()
 }
+
+describe('isPaneBusy', () => {
+  it('returns true when "esc to interrupt" appears in last 6 non-blank lines', () => {
+    const text = 'some output\nmore output\nesc to interrupt'
+    expect(isPaneBusy(text)).toBe(true)
+  })
+
+  it('returns true for "Working..." in last 6 lines', () => {
+    const text = 'line1\nline2\nWorking...'
+    expect(isPaneBusy(text)).toBe(true)
+  })
+
+  it('is case-insensitive for busy patterns', () => {
+    expect(isPaneBusy('ESC TO INTERRUPT')).toBe(true)
+    expect(isPaneBusy('WORKING...')).toBe(true)
+  })
+
+  it('returns false when no busy pattern present', () => {
+    expect(isPaneBusy('some idle output\nwaiting for input')).toBe(false)
+  })
+
+  it('ignores busy patterns that appear only beyond the last 6 non-blank lines', () => {
+    const lines = [
+      'esc to interrupt', // this is older, beyond last 6
+      'line a',
+      'line b',
+      'line c',
+      'line d',
+      'line e',
+      'line f',
+      'idle now',
+    ]
+    const text = lines.join('\n')
+    expect(isPaneBusy(text)).toBe(false)
+  })
+
+  it('strips ANSI escape sequences before matching', () => {
+    const text = '\x1b[1mesc to interrupt\x1b[0m'
+    expect(isPaneBusy(text)).toBe(true)
+  })
+
+  it('handles empty string', () => {
+    expect(isPaneBusy('')).toBe(false)
+  })
+})
 
 describe('checkStuckWorkers', () => {
   let db: Database.Database
@@ -144,5 +189,99 @@ describe('checkStuckWorkers', () => {
 
     const task = db.prepare("SELECT status FROM tasks WHERE id = 't1'").get() as { status: string }
     expect(task.status).toBe('in_progress') // not failed — agent is done, not running
+  })
+
+  // --- tmux pane busy-detection tests ---
+
+  it('skips stuck check when tmux pane shows "esc to interrupt"', () => {
+    // Old logs that would normally trigger a timeout
+    db.prepare(
+      "INSERT INTO logs (task_id, level, message, created_at) VALUES ('t1', 'info', 'old', ?)"
+    ).run(minutesAgo(TIMEOUT_MINUTES + 5))
+    db.prepare("UPDATE agents SET tmux_pane = 'sess:mc-t1' WHERE id = 'a1'").run()
+
+    const stuckSince = new Map<string, number>()
+    const mockCapture = (_target: string, _lines: number) => 'some output\nesc to interrupt'
+    checkStuckWorkers(db, stuckSince, WARNING_MINUTES, TIMEOUT_MINUTES, Date.now(), mockCapture)
+
+    const task = db.prepare("SELECT status FROM tasks WHERE id = 't1'").get() as { status: string }
+    expect(task.status).toBe('in_progress') // not failed — pane is busy
+    expect(stuckSince.has('t1')).toBe(false)
+  })
+
+  it('skips stuck check when tmux pane shows "Working..."', () => {
+    db.prepare(
+      "UPDATE tasks SET started_at = ? WHERE id = 't1'"
+    ).run(minutesAgo(TIMEOUT_MINUTES + 5))
+    db.prepare("UPDATE agents SET tmux_pane = 'sess:mc-t1' WHERE id = 'a1'").run()
+
+    const stuckSince = new Map<string, number>()
+    const mockCapture = (_target: string, _lines: number) => 'line1\nline2\nWorking...'
+    checkStuckWorkers(db, stuckSince, WARNING_MINUTES, TIMEOUT_MINUTES, Date.now(), mockCapture)
+
+    const task = db.prepare("SELECT status FROM tasks WHERE id = 't1'").get() as { status: string }
+    expect(task.status).toBe('in_progress')
+  })
+
+  it('uses correct pane target and line count when capturing', () => {
+    db.prepare("UPDATE agents SET tmux_pane = 'mysess:mc-task1' WHERE id = 'a1'").run()
+
+    const calls: Array<[string, number]> = []
+    const mockCapture = (target: string, lines: number) => {
+      calls.push([target, lines])
+      return 'idle output'
+    }
+
+    const stuckSince = new Map<string, number>()
+    checkStuckWorkers(db, stuckSince, WARNING_MINUTES, TIMEOUT_MINUTES, Date.now(), mockCapture)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0][0]).toBe('mysess:mc-task1')
+    expect(calls[0][1]).toBe(6)
+  })
+
+  it('falls through to timestamp check when pane is not busy', () => {
+    db.prepare(
+      "INSERT INTO logs (task_id, level, message, created_at) VALUES ('t1', 'info', 'old', ?)"
+    ).run(minutesAgo(TIMEOUT_MINUTES + 1))
+    db.prepare("UPDATE agents SET tmux_pane = 'sess:mc-t1' WHERE id = 'a1'").run()
+
+    const stuckSince = new Map<string, number>()
+    // Pane is idle — should fall through to timestamp-based check
+    const mockCapture = (_target: string, _lines: number) => 'idle pane output'
+    checkStuckWorkers(db, stuckSince, WARNING_MINUTES, TIMEOUT_MINUTES, Date.now(), mockCapture)
+
+    const task = db.prepare("SELECT status FROM tasks WHERE id = 't1'").get() as { status: string }
+    expect(task.status).toBe('failed') // timed out as normal
+  })
+
+  it('clears stuckSince when busy pane is detected', () => {
+    db.prepare(
+      "INSERT INTO logs (task_id, level, message, created_at) VALUES ('t1', 'info', 'old', ?)"
+    ).run(minutesAgo(WARNING_MINUTES + 1))
+    db.prepare("UPDATE agents SET tmux_pane = 'sess:mc-t1' WHERE id = 'a1'").run()
+
+    const stuckSince = new Map<string, number>()
+    stuckSince.set('t1', Date.now() - 60_000) // simulate previously detected as stuck
+
+    const mockCapture = (_target: string, _lines: number) => 'Working...'
+    checkStuckWorkers(db, stuckSince, WARNING_MINUTES, TIMEOUT_MINUTES, Date.now(), mockCapture)
+
+    // Busy pane clears stuck tracking
+    expect(stuckSince.has('t1')).toBe(false)
+  })
+
+  it('does not capture pane when agent has no tmux_pane', () => {
+    // No tmux_pane set on agent
+    const captureCallCount = { n: 0 }
+    const mockCapture = (_target: string, _lines: number) => {
+      captureCallCount.n++
+      return ''
+    }
+
+    const stuckSince = new Map<string, number>()
+    checkStuckWorkers(db, stuckSince, WARNING_MINUTES, TIMEOUT_MINUTES, Date.now(), mockCapture)
+
+    expect(captureCallCount.n).toBe(0) // no capture attempted
   })
 })

--- a/tests/spawner/tmux-send.test.ts
+++ b/tests/spawner/tmux-send.test.ts
@@ -23,6 +23,7 @@ import {
   cleanComposerLine,
   capturePaneText,
   sendToPane,
+  classifyComposerState,
 } from '../../src/spawner/tmux.js'
 
 describe('stripAnsiDim', () => {
@@ -215,5 +216,105 @@ describe('sendToPane', () => {
 
     const result = sendToPane('sess:win', 'test message', { retryDelayMs: 0 })
     expect(result.sent).toBe(true)
+  })
+})
+
+describe('classifyComposerState', () => {
+  // --- busy-footer cases ---
+
+  it('returns unknown when pane shows ESC to interrupt (busy-footer)', () => {
+    const pane = 'claude is thinking...\nESC to interrupt\n'
+    expect(classifyComposerState(pane, 'my text')).toBe('unknown')
+  })
+
+  it('returns unknown even if text is present when busy-footer is visible', () => {
+    // Text might still be in the pane but Claude is processing — indeterminate
+    const pane = 'my text\nESC to interrupt\n'
+    expect(classifyComposerState(pane, 'my text')).toBe('unknown')
+  })
+
+  // --- bordered cases ---
+
+  it('returns empty for bordered composer with only ghost-text placeholder', () => {
+    // │ [ghost dim placeholder] │ — borders + dim, no real user text
+    const pane = '│ \x1b[2mType a message…\x1b[22m │'
+    expect(classifyComposerState(pane, 'hello world')).toBe('empty')
+  })
+
+  it('returns pending for bordered composer with user text inside', () => {
+    // │ hello world │ — the text is genuinely there
+    const pane = '│ hello world │'
+    expect(classifyComposerState(pane, 'hello world')).toBe('pending')
+  })
+
+  it('returns empty for bordered composer that is truly empty (no text, no ghost)', () => {
+    const pane = '│  │'
+    expect(classifyComposerState(pane, 'hello world')).toBe('empty')
+  })
+
+  it('returns pending for bordered composer using heavy-line box-drawing (┃)', () => {
+    const pane = '┃ hello world ┃'
+    expect(classifyComposerState(pane, 'hello world')).toBe('pending')
+  })
+
+  // --- ghost-text cases ---
+
+  it('returns empty when pane contains only dim ghost-text placeholder (no real input)', () => {
+    // Entire composer content is dim placeholder — stripped → empty
+    const pane = '\x1b[2mType a message here\x1b[22m'
+    expect(classifyComposerState(pane, 'hello world')).toBe('empty')
+  })
+
+  it('returns pending when real text follows ghost placeholder', () => {
+    // Ghost placeholder + actual user content
+    const pane = '\x1b[2mhint\x1b[22m hello world'
+    expect(classifyComposerState(pane, 'hello world')).toBe('pending')
+  })
+
+  it('returns empty when ghost-text alone matches the submitted text after stripping', () => {
+    // The submitted text matches ghost placeholder text — strip dim → becomes empty
+    const pane = '\x1b[2mhello world\x1b[22m'
+    expect(classifyComposerState(pane, 'hello world')).toBe('empty')
+  })
+
+  // --- bare-prompt cases ---
+
+  it('returns pending for bare prompt with user text', () => {
+    // Simple > prompt, text visible, no decoration
+    const pane = '> hello world'
+    expect(classifyComposerState(pane, 'hello world')).toBe('pending')
+  })
+
+  it('returns empty for bare prompt with no text', () => {
+    const pane = '> '
+    expect(classifyComposerState(pane, 'hello world')).toBe('empty')
+  })
+
+  it('returns empty for bare prompt where text was submitted (pane scrolled)', () => {
+    // After submission the composer is cleared
+    const pane = '❯ '
+    expect(classifyComposerState(pane, 'hello world')).toBe('empty')
+  })
+
+  it('returns pending for bare prompt with text and ANSI colors', () => {
+    const pane = '> \x1b[32mhello world\x1b[0m'
+    expect(classifyComposerState(pane, 'hello world')).toBe('pending')
+  })
+
+  // --- edge cases ---
+
+  it('returns empty for completely empty pane', () => {
+    expect(classifyComposerState('', 'hello world')).toBe('empty')
+  })
+
+  it('returns empty when submittedText is empty string', () => {
+    // Empty submitted text — nothing to look for → always empty
+    expect(classifyComposerState('some content here', '')).toBe('empty')
+  })
+
+  it('returns pending for multi-line pane where text appears on any line', () => {
+    // Full pane capture includes many lines; the composer line has our text
+    const pane = 'previous output line\nanother line\n> hello world\n'
+    expect(classifyComposerState(pane, 'hello world')).toBe('pending')
   })
 })

--- a/tests/spawner/tmux-send.test.ts
+++ b/tests/spawner/tmux-send.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mockExecSync } = vi.hoisted(() => ({
+  mockExecSync: vi.fn(),
+}))
+
+vi.mock('child_process', () => ({
+  execSync: mockExecSync,
+  spawn: vi.fn(() => ({ on: vi.fn(), unref: vi.fn() })),
+}))
+
+vi.mock('fs', () => ({
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  existsSync: vi.fn(() => false),
+  readFileSync: vi.fn(() => ''),
+  openSync: vi.fn(() => 1),
+}))
+
+import {
+  stripAnsiDim,
+  stripBoxDrawing,
+  cleanComposerLine,
+  capturePaneText,
+  sendToPane,
+} from '../../src/spawner/tmux.js'
+
+describe('stripAnsiDim', () => {
+  it('removes SGR 2 (dim/faint) text and its reset', () => {
+    // \x1b[2m marks dim start, \x1b[22m resets intensity
+    const input = 'visible \x1b[2mghost text\x1b[22m more visible'
+    expect(stripAnsiDim(input)).toBe('visible  more visible')
+  })
+
+  it('handles dim text at end of line (no closing reset)', () => {
+    const input = 'prompt> \x1b[2msuggestion here'
+    expect(stripAnsiDim(input)).toBe('prompt> ')
+  })
+
+  it('handles nested SGR sequences inside dim region', () => {
+    const input = 'ok \x1b[2m\x1b[37mghost\x1b[0m rest'
+    // SGR 0 (full reset) also ends dim
+    expect(stripAnsiDim(input)).toBe('ok  rest')
+  })
+
+  it('returns unmodified string when no dim sequences present', () => {
+    const input = 'no dim here'
+    expect(stripAnsiDim(input)).toBe('no dim here')
+  })
+
+  it('handles multiple dim regions', () => {
+    const input = 'a \x1b[2mb\x1b[22m c \x1b[2md\x1b[22m e'
+    expect(stripAnsiDim(input)).toBe('a  c  e')
+  })
+
+  it('handles SGR 2 combined with other attributes', () => {
+    // \x1b[1;2m sets bold+dim
+    const input = 'before \x1b[1;2mfaint bold\x1b[22m after'
+    expect(stripAnsiDim(input)).toBe('before  after')
+  })
+})
+
+describe('stripBoxDrawing', () => {
+  it('removes Unicode box-drawing characters │ ┃', () => {
+    expect(stripBoxDrawing('│ hello ┃')).toBe(' hello ')
+  })
+
+  it('removes ASCII pipe used as border', () => {
+    expect(stripBoxDrawing('| text |')).toBe(' text ')
+  })
+
+  it('returns unmodified string when no borders present', () => {
+    expect(stripBoxDrawing('just text')).toBe('just text')
+  })
+
+  it('handles lines with only box drawing', () => {
+    expect(stripBoxDrawing('│││')).toBe('')
+  })
+})
+
+describe('cleanComposerLine', () => {
+  it('strips dim ghost text and box borders together', () => {
+    const input = '│ prompt> \x1b[2msuggestion\x1b[22m │'
+    const result = cleanComposerLine(input)
+    expect(result).toBe('prompt>')
+  })
+
+  it('strips all remaining ANSI sequences after dim removal', () => {
+    const input = '\x1b[1;32mprompt>\x1b[0m hello'
+    const result = cleanComposerLine(input)
+    expect(result).toBe('prompt> hello')
+  })
+
+  it('trims whitespace', () => {
+    const input = '   some text   '
+    expect(cleanComposerLine(input)).toBe('some text')
+  })
+
+  it('returns empty string for border-only line', () => {
+    const input = '│ \x1b[2m \x1b[22m │'
+    expect(cleanComposerLine(input)).toBe('')
+  })
+})
+
+describe('capturePaneText', () => {
+  beforeEach(() => {
+    mockExecSync.mockReset()
+  })
+
+  it('calls tmux capture-pane with -e flag for ANSI escapes and -p to print', () => {
+    mockExecSync.mockReturnValueOnce('line1\nline2\n')
+    capturePaneText('sess:win')
+    const call = mockExecSync.mock.calls[0][0] as string
+    expect(call).toContain('capture-pane')
+    expect(call).toContain('-e')
+    expect(call).toContain('-p')
+    expect(call).toContain('-t')
+  })
+
+  it('returns trimmed captured text', () => {
+    mockExecSync.mockReturnValueOnce('  content here  \n\n')
+    const result = capturePaneText('sess:win')
+    expect(result).toBe('content here')
+  })
+
+  it('returns empty string on failure', () => {
+    mockExecSync.mockImplementationOnce(() => { throw new Error('pane gone') })
+    const result = capturePaneText('sess:win')
+    expect(result).toBe('')
+  })
+})
+
+describe('sendToPane', () => {
+  beforeEach(() => {
+    mockExecSync.mockReset()
+  })
+
+  it('sends text via send-keys then verifies with capture-pane', () => {
+    // First call: send-keys for the text
+    mockExecSync.mockReturnValueOnce(undefined)
+    // Second call: send-keys Enter
+    mockExecSync.mockReturnValueOnce(undefined)
+    // Third call: capture-pane to verify submit (empty = submitted)
+    mockExecSync.mockReturnValueOnce('\n\n')
+
+    const result = sendToPane('sess:win', 'hello world', { retryDelayMs: 0 })
+    expect(result.sent).toBe(true)
+    // send-keys for text, send-keys Enter, capture-pane verify
+    expect(mockExecSync).toHaveBeenCalledTimes(3)
+  })
+
+  it('retries Enter when capture-pane shows text still in composer', () => {
+    // send-keys text
+    mockExecSync.mockReturnValueOnce(undefined)
+    // send-keys Enter (attempt 0)
+    mockExecSync.mockReturnValueOnce(undefined)
+    // capture-pane: text still there (not submitted)
+    mockExecSync.mockReturnValueOnce('hello world\n')
+    // send-keys Enter (attempt 1 = retry)
+    mockExecSync.mockReturnValueOnce(undefined)
+    // capture-pane: now clear
+    mockExecSync.mockReturnValueOnce('\n\n')
+
+    const result = sendToPane('sess:win', 'hello world', { retryDelayMs: 0 })
+    expect(result.sent).toBe(true)
+    expect(result.enterRetries).toBe(1)
+  })
+
+  it('does not retype text on retry, only resends Enter', () => {
+    // send-keys text
+    mockExecSync.mockReturnValueOnce(undefined)
+    // send-keys Enter (attempt 0)
+    mockExecSync.mockReturnValueOnce(undefined)
+    // capture-pane: still there
+    mockExecSync.mockReturnValueOnce('hello world\n')
+    // send-keys Enter (attempt 1 = retry)
+    mockExecSync.mockReturnValueOnce(undefined)
+    // capture-pane: clear
+    mockExecSync.mockReturnValueOnce('\n\n')
+
+    sendToPane('sess:win', 'hello world', { retryDelayMs: 0 })
+
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string)
+    // Only the first call should contain the actual text
+    const textSends = calls.filter(c => c.includes('send-keys') && c.includes('hello world'))
+    expect(textSends).toHaveLength(1)
+    // The retry should be Enter-only
+    const enterOnlySends = calls.filter(c => c.includes('send-keys') && !c.includes('hello world') && c.includes('Enter'))
+    expect(enterOnlySends.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('gives up after max retries and returns sent=false', () => {
+    // send-keys text
+    mockExecSync.mockReturnValueOnce(undefined)
+
+    // For each attempt (1 initial + 3 retries = 4 total):
+    // send-keys Enter, then capture-pane showing text still there
+    for (let i = 0; i < 4; i++) {
+      mockExecSync.mockReturnValueOnce(undefined) // Enter
+      mockExecSync.mockReturnValueOnce('hello world\n') // capture-pane
+    }
+
+    const result = sendToPane('sess:win', 'hello world', { maxEnterRetries: 3, retryDelayMs: 0 })
+    expect(result.sent).toBe(false)
+    expect(result.enterRetries).toBe(3)
+  })
+
+  it('handles bordered composer with dim ghost text correctly', () => {
+    // send-keys text
+    mockExecSync.mockReturnValueOnce(undefined)
+    // send-keys Enter
+    mockExecSync.mockReturnValueOnce(undefined)
+    // capture-pane: border-only with dim ghost = effectively empty = submitted
+    mockExecSync.mockReturnValueOnce('│ \x1b[2mType a message\x1b[22m │\n')
+
+    const result = sendToPane('sess:win', 'test message', { retryDelayMs: 0 })
+    expect(result.sent).toBe(true)
+  })
+})

--- a/tests/spawner/tmux.test.ts
+++ b/tests/spawner/tmux.test.ts
@@ -26,6 +26,7 @@ import {
   getTmuxPanePid,
   sendTmuxKeys,
   writeLaunchScript,
+  captureTmuxPane,
 } from '../../src/spawner/tmux.js'
 
 describe('ensureTmuxSession', () => {
@@ -145,6 +146,50 @@ describe('sendTmuxKeys', () => {
     sendTmuxKeys('mysess:mywin', 'ls')
     const call = mockExecSync.mock.calls[0][0] as string
     expect(call).toContain('-t')
+  })
+})
+
+describe('captureTmuxPane', () => {
+  beforeEach(() => {
+    mockExecSync.mockReset()
+  })
+
+  it('runs capture-pane with the specified target', () => {
+    mockExecSync.mockReturnValueOnce('line1\nline2\n')
+    const result = captureTmuxPane('session:mc-task')
+    expect(result).toBe('line1\nline2\n')
+    const call = mockExecSync.mock.calls[0][0] as string
+    expect(call).toContain('capture-pane')
+    expect(call).toContain('-p')
+    expect(call).toContain('session:mc-task')
+  })
+
+  it('uses default of 40 lines when none specified', () => {
+    mockExecSync.mockReturnValueOnce('')
+    captureTmuxPane('sess:win')
+    const call = mockExecSync.mock.calls[0][0] as string
+    expect(call).toContain('-S -40')
+  })
+
+  it('uses the specified line count', () => {
+    mockExecSync.mockReturnValueOnce('')
+    captureTmuxPane('sess:win', 100)
+    const call = mockExecSync.mock.calls[0][0] as string
+    expect(call).toContain('-S -100')
+  })
+
+  it('returns empty string when tmux throws', () => {
+    mockExecSync.mockImplementationOnce(() => { throw new Error('no tmux') })
+    const result = captureTmuxPane('bad:target')
+    expect(result).toBe('')
+  })
+
+  it('shell-quotes target to handle special chars', () => {
+    mockExecSync.mockReturnValueOnce('')
+    captureTmuxPane("session:it's-special")
+    const call = mockExecSync.mock.calls[0][0] as string
+    // target should be quoted
+    expect(call).toContain("'session:it'\\''s-special'")
   })
 })
 

--- a/tests/spawner/tmux.test.ts
+++ b/tests/spawner/tmux.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { mockExecSync, mockSpawn, mockWriteFileSync, mockMkdirSync } = vi.hoisted(() => ({
+  mockExecSync: vi.fn(),
+  mockSpawn: vi.fn(() => ({ on: vi.fn(), unref: vi.fn() })),
+  mockWriteFileSync: vi.fn(),
+  mockMkdirSync: vi.fn(),
+}))
+
+vi.mock('child_process', () => ({
+  execSync: mockExecSync,
+  spawn: mockSpawn,
+}))
+
+vi.mock('fs', () => ({
+  writeFileSync: mockWriteFileSync,
+  mkdirSync: mockMkdirSync,
+  existsSync: vi.fn(() => false),
+  readFileSync: vi.fn(() => ''),
+  openSync: vi.fn(() => 1),
+}))
+
+import {
+  ensureTmuxSession,
+  createTmuxWindow,
+  getTmuxPanePid,
+  sendTmuxKeys,
+  writeLaunchScript,
+} from '../../src/spawner/tmux.js'
+
+describe('ensureTmuxSession', () => {
+  const origTmux = process.env.TMUX
+
+  beforeEach(() => {
+    mockExecSync.mockReset()
+  })
+
+  afterEach(() => {
+    if (origTmux === undefined) delete process.env.TMUX
+    else process.env.TMUX = origTmux
+  })
+
+  it('returns current session name when inside tmux', () => {
+    process.env.TMUX = '/tmp/tmux-1000/default,12345,0'
+    mockExecSync.mockReturnValueOnce('my-session\n')
+    const result = ensureTmuxSession()
+    expect(result).toBe('my-session')
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringContaining('display-message'),
+      expect.objectContaining({ encoding: 'utf8' })
+    )
+  })
+
+  it('reuses existing multiclaude session when not in tmux', () => {
+    delete process.env.TMUX
+    // has-session succeeds (session exists)
+    mockExecSync.mockReturnValueOnce(undefined)
+    const result = ensureTmuxSession()
+    expect(result).toBe('multiclaude')
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringContaining('has-session'),
+      expect.anything()
+    )
+    // new-session should NOT be called
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string)
+    expect(calls.some(c => c.includes('new-session'))).toBe(false)
+  })
+
+  it('creates a new multiclaude session when not in tmux and none exists', () => {
+    delete process.env.TMUX
+    // has-session throws (session does not exist)
+    mockExecSync.mockImplementationOnce(() => { throw new Error('no server running') })
+    // new-session succeeds
+    mockExecSync.mockReturnValueOnce(undefined)
+    const result = ensureTmuxSession()
+    expect(result).toBe('multiclaude')
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string)
+    expect(calls.some(c => c.includes('new-session'))).toBe(true)
+    expect(calls.some(c => c.includes('-d'))).toBe(true)
+  })
+})
+
+describe('createTmuxWindow', () => {
+  beforeEach(() => {
+    mockExecSync.mockReset()
+  })
+
+  it('calls tmux new-window with correct session, name and cwd', () => {
+    mockExecSync.mockReturnValueOnce(undefined)
+    const target = createTmuxWindow('my-session', 'task-1', '/tmp/worktree')
+    expect(target).toBe('my-session:mc-task-1')
+    const call = mockExecSync.mock.calls[0][0] as string
+    expect(call).toContain('new-window')
+    expect(call).toContain('-d')
+    expect(call).toContain('mc-task-1')
+    expect(call).toContain('/tmp/worktree')
+  })
+
+  it('uses mc- prefix for window name', () => {
+    mockExecSync.mockReturnValueOnce(undefined)
+    const target = createTmuxWindow('sess', 'my-task', '/path')
+    expect(target).toContain('mc-my-task')
+  })
+})
+
+describe('getTmuxPanePid', () => {
+  beforeEach(() => {
+    mockExecSync.mockReset()
+  })
+
+  it('returns parsed integer PID from tmux output', () => {
+    mockExecSync.mockReturnValueOnce('12345\n')
+    const pid = getTmuxPanePid('session:window')
+    expect(pid).toBe(12345)
+  })
+
+  it('returns undefined when execSync throws', () => {
+    mockExecSync.mockImplementationOnce(() => { throw new Error('tmux error') })
+    const pid = getTmuxPanePid('session:window')
+    expect(pid).toBeUndefined()
+  })
+
+  it('returns undefined for non-numeric output', () => {
+    mockExecSync.mockReturnValueOnce('not-a-number\n')
+    const pid = getTmuxPanePid('session:window')
+    expect(pid).toBeUndefined()
+  })
+})
+
+describe('sendTmuxKeys', () => {
+  beforeEach(() => {
+    mockExecSync.mockReset()
+  })
+
+  it('calls tmux send-keys with target and command', () => {
+    sendTmuxKeys('session:mc-task', 'echo hello')
+    const call = mockExecSync.mock.calls[0][0] as string
+    expect(call).toContain('send-keys')
+    expect(call).toContain('session:mc-task')
+    expect(call).toContain('echo hello')
+    expect(call).toContain('Enter')
+  })
+
+  it('passes -t flag to target the correct pane', () => {
+    sendTmuxKeys('mysess:mywin', 'ls')
+    const call = mockExecSync.mock.calls[0][0] as string
+    expect(call).toContain('-t')
+  })
+})
+
+describe('writeLaunchScript', () => {
+  beforeEach(() => {
+    mockWriteFileSync.mockReset()
+    mockMkdirSync.mockReset()
+    mockExecSync.mockReset()
+  })
+
+  it('writes an executable shell script to .claude/worker-launch.sh', () => {
+    const cfg = {
+      taskId: 'task-1',
+      taskTitle: 'Build something',
+      agentId: 'w-task-1',
+      worktreePath: '/tmp/worktree',
+      mcpConfigPath: '/tmp/mcp.json',
+    }
+    const scriptPath = writeLaunchScript(cfg)
+    expect(scriptPath).toContain('worker-launch.sh')
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('worker-launch.sh'),
+      expect.stringContaining('#!/usr/bin/env bash'),
+      expect.objectContaining({ mode: 0o755 })
+    )
+  })
+
+  it('includes exec claude in the script', () => {
+    const cfg = {
+      taskId: 'task-1',
+      taskTitle: 'Build something',
+      agentId: 'w-task-1',
+      worktreePath: '/tmp/worktree',
+      mcpConfigPath: '/tmp/mcp.json',
+    }
+    writeLaunchScript(cfg)
+    const scriptContent = mockWriteFileSync.mock.calls[0][1] as string
+    expect(scriptContent).toContain('exec claude')
+  })
+
+  it('sets MULTICLAUDE_AGENT_ID in the script', () => {
+    const cfg = {
+      taskId: 'task-2',
+      taskTitle: 'Another task',
+      agentId: 'w-task-2',
+      worktreePath: '/tmp/wt2',
+      mcpConfigPath: '/tmp/mcp.json',
+    }
+    writeLaunchScript(cfg)
+    const scriptContent = mockWriteFileSync.mock.calls[0][1] as string
+    expect(scriptContent).toContain('MULTICLAUDE_AGENT_ID')
+    expect(scriptContent).toContain('w-task-2')
+  })
+})

--- a/tests/spawner/tmux.test.ts
+++ b/tests/spawner/tmux.test.ts
@@ -27,6 +27,7 @@ import {
   sendTmuxKeys,
   writeLaunchScript,
   captureTmuxPane,
+  spawnTmuxWorker,
 } from '../../src/spawner/tmux.js'
 
 describe('ensureTmuxSession', () => {
@@ -242,5 +243,162 @@ describe('writeLaunchScript', () => {
     const scriptContent = mockWriteFileSync.mock.calls[0][1] as string
     expect(scriptContent).toContain('MULTICLAUDE_AGENT_ID')
     expect(scriptContent).toContain('w-task-2')
+  })
+})
+
+describe('spawnTmuxWorker', () => {
+  const cfg = {
+    taskId: 'task-42',
+    taskTitle: 'Build the thing',
+    agentId: 'w-task-42',
+    worktreePath: '/tmp/wt-42',
+    mcpConfigPath: '/tmp/mcp.json',
+  }
+
+  beforeEach(() => {
+    mockExecSync.mockReset()
+    mockSpawn.mockReset()
+    mockWriteFileSync.mockReset()
+    mockMkdirSync.mockReset()
+
+    // Default stubs for the full spawn sequence:
+    // 1. ensureTmuxSession (inside tmux check) — return session name
+    mockExecSync.mockReturnValueOnce('multiclaude\n')
+    // (Not inside $TMUX; has-session succeeds so no new-session call)
+    // 2. createTmuxWindow — succeeds silently
+    mockExecSync.mockReturnValueOnce(undefined)
+    // 3. getTmuxPanePid — returns a PID
+    mockExecSync.mockReturnValueOnce('9999\n')
+    // 4. sendTmuxKeys — send the launch script command
+    mockExecSync.mockReturnValueOnce(undefined)
+
+    // Monitor spawn
+    mockSpawn.mockReturnValue({ on: vi.fn(), unref: vi.fn() })
+
+    // Ensure not inside tmux for deterministic session path
+    delete process.env.TMUX
+  })
+
+  afterEach(() => {
+    delete process.env.TMUX
+  })
+
+  it('returns a WorkerHandle with tmuxPane set to session:mc-<taskId>', () => {
+    // ensureTmuxSession: has-session succeeds → 'multiclaude'
+    mockExecSync.mockReset()
+    mockExecSync.mockReturnValueOnce(undefined)    // has-session succeeds
+    mockExecSync.mockReturnValueOnce(undefined)    // new-window
+    mockExecSync.mockReturnValueOnce('9999\n')     // pane PID
+    mockExecSync.mockReturnValueOnce(undefined)    // send-keys
+
+    const handle = spawnTmuxWorker(cfg)
+    expect(handle.tmuxPane).toBe('multiclaude:mc-task-42')
+  })
+
+  it('sets pid from getTmuxPanePid output', () => {
+    mockExecSync.mockReset()
+    mockExecSync.mockReturnValueOnce(undefined)    // has-session
+    mockExecSync.mockReturnValueOnce(undefined)    // new-window
+    mockExecSync.mockReturnValueOnce('12345\n')    // pane PID
+    mockExecSync.mockReturnValueOnce(undefined)    // send-keys
+
+    const handle = spawnTmuxWorker(cfg)
+    expect(handle.pid).toBe(12345)
+  })
+
+  it('pid is undefined when getTmuxPanePid fails', () => {
+    mockExecSync.mockReset()
+    mockExecSync.mockReturnValueOnce(undefined)                              // has-session
+    mockExecSync.mockReturnValueOnce(undefined)                              // new-window
+    mockExecSync.mockImplementationOnce(() => { throw new Error('nopid') }) // pane PID fails
+    mockExecSync.mockReturnValueOnce(undefined)                              // send-keys
+
+    const handle = spawnTmuxWorker(cfg)
+    expect(handle.pid).toBeUndefined()
+  })
+
+  it('spawns a tmux wait-for monitor process for the exit signal', () => {
+    mockExecSync.mockReset()
+    mockExecSync.mockReturnValueOnce(undefined)  // has-session
+    mockExecSync.mockReturnValueOnce(undefined)  // new-window
+    mockExecSync.mockReturnValueOnce('9999\n')   // PID
+    mockExecSync.mockReturnValueOnce(undefined)  // send-keys
+
+    spawnTmuxWorker(cfg)
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'tmux',
+      ['wait-for', 'mc-task-42-exit'],
+      expect.objectContaining({ stdio: 'ignore', detached: false })
+    )
+  })
+
+  it('sends the launch script to the pane via send-keys', () => {
+    mockExecSync.mockReset()
+    mockExecSync.mockReturnValueOnce(undefined)  // has-session
+    mockExecSync.mockReturnValueOnce(undefined)  // new-window
+    mockExecSync.mockReturnValueOnce('9999\n')   // PID
+    mockExecSync.mockReturnValueOnce(undefined)  // send-keys
+
+    spawnTmuxWorker(cfg)
+
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string)
+    const sendKeysCall = calls.find(c => c.includes('send-keys') && c.includes('worker-launch.sh'))
+    expect(sendKeysCall).toBeDefined()
+    // Should include "Enter" to execute the command
+    expect(sendKeysCall).toContain('Enter')
+  })
+
+  it('appends tmux wait-for signal to the send-keys command', () => {
+    mockExecSync.mockReset()
+    mockExecSync.mockReturnValueOnce(undefined)  // has-session
+    mockExecSync.mockReturnValueOnce(undefined)  // new-window
+    mockExecSync.mockReturnValueOnce('9999\n')   // PID
+    mockExecSync.mockReturnValueOnce(undefined)  // send-keys
+
+    spawnTmuxWorker(cfg)
+
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string)
+    const sendKeysCall = calls.find(c => c.includes('send-keys'))
+    expect(sendKeysCall).toContain('wait-for -S')
+    expect(sendKeysCall).toContain('mc-task-42-exit')
+  })
+
+  it('writes settings.local.json before spawning', () => {
+    mockExecSync.mockReset()
+    mockExecSync.mockReturnValueOnce(undefined)  // has-session
+    mockExecSync.mockReturnValueOnce(undefined)  // new-window
+    mockExecSync.mockReturnValueOnce('9999\n')   // PID
+    mockExecSync.mockReturnValueOnce(undefined)  // send-keys
+
+    spawnTmuxWorker(cfg)
+
+    const settingsCall = mockWriteFileSync.mock.calls.find(
+      (c: unknown[]) => (c[0] as string).includes('settings.local.json')
+    )
+    expect(settingsCall).toBeDefined()
+    const content = JSON.parse(settingsCall![1] as string)
+    expect(content.permissions.allow).toContain('Bash(*)')
+  })
+
+  it('exposes onExit and onError via the monitor process events', () => {
+    mockExecSync.mockReset()
+    mockExecSync.mockReturnValueOnce(undefined)  // has-session
+    mockExecSync.mockReturnValueOnce(undefined)  // new-window
+    mockExecSync.mockReturnValueOnce('9999\n')   // PID
+    mockExecSync.mockReturnValueOnce(undefined)  // send-keys
+
+    const onMock = vi.fn()
+    mockSpawn.mockReturnValue({ on: onMock, unref: vi.fn() })
+
+    const handle = spawnTmuxWorker(cfg)
+
+    const exitCb = vi.fn()
+    const errCb = vi.fn()
+    handle.onExit(exitCb)
+    handle.onError(errCb)
+
+    expect(onMock).toHaveBeenCalledWith('exit', exitCb)
+    expect(onMock).toHaveBeenCalledWith('error', errCb)
   })
 })


### PR DESCRIPTION
Adds an opt-in **tmux worker runtime backend** so worker agents run inside attachable tmux windows instead of detached subprocesses — inspired by Kun Chen's firstmate (docs/tmux-backend.md, bin/backends/tmux.sh, bin/fm-tmux-lib.sh).

## Tasks included
- **backend-seam**: Introduced a pluggable runtime-backend seam in src/spawner; the existing detached-subprocess path becomes the default backend, and tmux is now an accepted workerRuntime value in src/config.ts / .multiclaude.json.
- **tmux-spawn**: Implemented the tmux spawn path — ensure a session (reuse the current $TMUX session if inside one, else a detached "multiclaude" session), create an mc-<taskId> window rooted at the worktree, and launch the agent inside the pane so it is attachable.
- **tmux-peek**: Added a bounded read-only capture-pane API exposed to the TUI and web dashboard for a live per-worker pane view (beyond report_progress snapshots).
- **tmux-send**: Added a send/steer channel with composer-submit robustness — capture-pane -e to read the composer with ANSI styling, strip dim/faint (SGR 2) ghost text and box-drawing borders, then verify-and-retry-Enter (retry Enter only, never retype). Avoids the two failure modes firstmate documented.
- **stuck-watcher-busy**: Wired pane busy-footer detection ("esc to interrupt" / "Working...") into src/spawner/stuck-watcher.ts so a mid-turn worker is not flagged stuck.
- **tests-tmux**: Vitest coverage for the tmux backend — session/window naming, spawn command sequence, capture parsing, and the composer-state classifier across bordered / ghost-text / busy-footer / bare-prompt cases.

## Not included
- **docs-update** (CLAUDE.md/README + init template) was dropped from this run: its worker reproducibly completed the edits (~13k tokens) then crashed before report_done. Docs to be added in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
