### PR TITLE
Document the tmux worker backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,14 @@ src/spawner/index.ts     spawnWorker(): launches `claude` subprocess with --mcp-
                          --dangerously-skip-permissions, and a prompt injected via CLI arg.
                          Writes .claude/settings.local.json into the worktree before spawning.
 src/spawner/cursor.ts    Cursor worker variant — uses node-pty for PTY requirement.
+src/spawner/tmux.ts      Tmux worker backend: ensureTmuxSession, createTmuxWindow, spawnTmuxWorker,
+                         captureTmuxPane, sendToPane (with composer-submit robustness), and
+                         classifyComposerState (busy-footer / pending / empty detection).
+src/spawner/backend.ts   Runtime backend seam: ProcessBackend | CursorBackend | TmuxBackend,
+                         selected via createBackend(runtime) based on .multiclaude.json config.
 src/spawner/stuck-watcher.ts  Detects agents that haven't progressed past thresholds.
+                         For tmux workers, checks captureTmuxPane output for a busy footer
+                         ("ESC to interrupt") before classifying a worker as stuck.
 
 src/git/worktree.ts      createWorktree / removeWorktree using git worktree add.
                          branchNameFromTitle() derives branch names from task titles.
@@ -68,7 +75,7 @@ src/web/server.ts        Express web dashboard with SSE live updates on port 743
 
 prompts/orchestrator.md  System prompt injected into CLAUDE.md of target projects.
 prompts/worker.md        System prompt passed as CLI arg to each worker subprocess.
-tests/                   Vitest test suite (31 tests).
+tests/                   Vitest test suite (214 tests across 20 files).
 ```
 
 ### Git isolation model
@@ -85,6 +92,31 @@ worker calls `report_done` → `handleReportDone` in [worker.ts](src/server/tool
 
 **Retry flow:**
 subprocess exits without calling `report_done` → spawner watcher marks agent `failed` → spawner watcher auto-retries up to `max_retries` (default 3) times → on final failure, orchestrator escalates to user
+
+### Tmux worker runtime
+
+Set `workerRuntime: "tmux"` in `.multiclaude.json` (or pass `--worker-runtime=tmux` to `multiclaude start`) to run workers inside tmux windows instead of detached subprocesses.
+
+**How it runs:** `spawnTmuxWorker` in `src/spawner/tmux.ts` (selected through `TmuxBackend` in `src/spawner/backend.ts`):
+1. Resolves a tmux session — reuses the current session when `$TMUX` is set; otherwise creates or reuses a detached `multiclaude` session.
+2. Creates a window named `mc-<taskId>` rooted at the worktree path.
+3. Writes a `worker-launch.sh` script into the worktree's `.claude/` directory and sends it to the pane via `send-keys`.
+4. Spawns a `tmux wait-for` monitor process that unblocks when the pane's command exits.
+
+**How to attach:**
+```bash
+tmux attach              # if multiclaude was started outside tmux
+# or select the window if already inside tmux:
+# Ctrl-b w → pick mc-<taskId>
+```
+Each worker runs in its own `mc-<taskId>` window. You can watch it live, scroll its history, and interact with it normally.
+
+**Supervision model:**
+- **TUI** (`src/tui/index.tsx`): polls `captureTmuxPane` every second and shows the last non-empty line of each running worker's pane below the task row (`↳ <last pane line>`).
+- **Web dashboard** (`src/web/server.ts`, `src/web/public/run.html`): exposes `GET /api/peek/:agentId?lines=<n>` which calls `captureTmuxPane` and returns raw pane content. The run detail page shows a **PANE** tab (alongside LOGS) for tasks that have a tmux pane; it polls `/api/peek` every 2 seconds and renders the output line by line.
+- **Send/steer channel:** `sendToPane(target, text, opts)` types text into a pane and verifies submission by reading back pane content. It handles four Claude Code composer layouts (bordered, ghost-text, busy-footer, bare-prompt) and retries pressing Enter (without retyping the text) if the composer still shows the input after the first keystroke.
+
+**Busy-footer detection** (`src/spawner/stuck-watcher.ts`): before marking a tmux worker as stuck, the watcher calls `captureTmuxPane` and checks the last 6 non-blank lines for `"ESC to interrupt"` or `"working..."`. A pane showing a busy indicator is skipped — the worker is mid-turn, not stuck.
 
 ### MCP transport
 

--- a/README.md
+++ b/README.md
@@ -192,13 +192,86 @@ On `multiclaude start`, the server also writes:
 | Init flag | `--claude` (default) | `--cursor` |
 | System instructions | `CLAUDE.md` | `.cursor/rules/*.mdc` |
 
+## Tmux Worker Runtime
+
+MultiClaude can run worker agents inside tmux windows instead of detached subprocesses, giving you full terminal access to each worker.
+
+### Prerequisites
+
+- tmux installed and available on your `$PATH`
+
+### Setup
+
+```bash
+# In your project directory, init as usual (tmux workers still use the claude CLI):
+multiclaude init
+
+# Then edit .multiclaude.json to set the runtime:
+# { "workerRuntime": "tmux" }
+```
+
+Or pass the flag at server start time (overrides `.multiclaude.json`):
+
+```bash
+multiclaude start --worker-runtime=tmux
+```
+
+### How it works
+
+Each worker launches inside its own tmux window named `mc-<taskId>`. The spawner:
+1. Reuses the active tmux session when `$TMUX` is set, otherwise creates (or reuses) a detached `multiclaude` session.
+2. Opens a window named `mc-<taskId>` rooted at the worker's git worktree.
+3. Writes a `worker-launch.sh` script into `.claude/` and sends it to the pane via `send-keys`.
+4. Monitors exit via `tmux wait-for` so the spawner watcher detects when the worker finishes.
+
+### Attaching to a worker
+
+```bash
+# If multiclaude was launched outside tmux:
+tmux attach -t multiclaude
+
+# If you're already inside tmux, list windows and select mc-<taskId>:
+# Ctrl-b w
+```
+
+Each worker's output is visible in its own window. You can scroll, copy, and interact with it like any normal tmux window.
+
+### Observability
+
+**TUI:** For each running tmux worker, the TUI polls `tmux capture-pane` every second and shows the last non-empty line below the task row (`↳ <last pane line>`). If the pane is unavailable, it falls back to the last MCP log entry.
+
+**Web dashboard:** The run detail page (`http://localhost:7433/runs/<id>`) shows a **PANE** tab for tasks that have a tmux pane. It polls `GET /api/peek/:agentId` every 2 seconds and renders the pane output line by line. The **LOGS** tab remains available alongside it.
+
+**Send/steer channel:** `sendToPane()` in `src/spawner/tmux.ts` provides a programmatic way to type text into a worker's pane and verify it was submitted. It handles four Claude Code composer layouts (bordered box-drawing, dim ghost-text placeholders, busy-footer, bare prompt) and retries pressing Enter without retyping the text if the composer still shows the input after the first keystroke.
+
+### Busy-footer detection
+
+The stuck-watcher reads the last 6 non-blank lines of a tmux worker's pane before evaluating whether it is stuck. If the pane shows a Claude Code busy indicator (`ESC to interrupt` or `working...`), the worker is considered mid-turn and the stuck timer is reset. This prevents false timeouts when a worker is doing a long computation but hasn't logged a progress update recently.
+
+### Testing the tmux backend
+
+```bash
+npm test                                      # run the full suite (214 tests)
+npx vitest run tests/spawner/tmux.test.ts     # core tmux functions (session, window, PID, send-keys, spawn)
+npx vitest run tests/spawner/tmux-send.test.ts  # sendToPane + classifyComposerState (all layout variants)
+npx vitest run tests/spawner/backend.test.ts  # backend seam: createBackend returns the right class
+npx vitest run tests/spawner/stuck-watcher.test.ts  # busy-footer skip logic
+```
+
+**Manual attach walkthrough:**
+1. Start `multiclaude start --worker-runtime=tmux` in one terminal.
+2. In your project directory, run `claude` (the orchestrator) and give it a task.
+3. As workers spawn, you should see tmux windows appear: `tmux list-windows -t multiclaude`.
+4. Attach: `tmux attach -t multiclaude`, then switch to any `mc-<taskId>` window to watch the agent live.
+5. When the worker calls `report_done`, its window remains open — you can review its output before cleaning up.
+
 ## Run Tests
 
 ```bash
 npm test
 ```
 
-31 tests across state management, DAG engine, MCP tool handlers, git worktrees, and the server.
+214 tests across state management, DAG engine, MCP tool handlers, git worktrees, spawner backends, and the coordination server.
 
 ## Project Structure
 
@@ -217,7 +290,9 @@ src/
   git/
     worktree.ts           # createWorktree, removeWorktree
     merge.ts              # ensureIntegrationBranch, mergeWorktreeBranch
-  spawner/index.ts        # spawnWorker, buildWorkerMcpConfig
+  spawner/index.ts        # spawnWorker (process backend), buildWorkerMcpConfig
+  spawner/tmux.ts         # tmux worker backend: session/window management, pane capture, sendToPane
+  spawner/backend.ts      # runtime backend seam: ProcessBackend | CursorBackend | TmuxBackend
   tui/index.tsx           # Ink TUI dashboard
   web/server.ts           # Web dashboard (SSE live updates)
   cli.ts                  # Entry point

--- a/src/init.ts
+++ b/src/init.ts
@@ -48,10 +48,15 @@ export function runInit(opts: InitOptions = {}): void {
     console.log(`  .cursor/rules/multiclaude-orchestrator.mdc — orchestrator instructions added`)
   } else {
     updateClaudeMd(projectDir)
-    console.log(`✓ MultiClaude initialized in ${projectDir}`)
-    console.log(`  .multiclaude.json — workerRuntime: claude`)
+    const suffix = runtime === 'tmux' ? ' (tmux mode)' : ''
+    console.log(`✓ MultiClaude initialized in ${projectDir}${suffix}`)
+    console.log(`  .multiclaude.json — workerRuntime: ${runtime}`)
     console.log(`  .claude/settings.local.json — permissions added`)
     console.log(`  CLAUDE.md — orchestrator instructions added`)
+    if (runtime === 'tmux') {
+      console.log(`\nWorkers will run inside tmux windows named mc-<taskId>.`)
+      console.log(`Attach with: tmux attach -t multiclaude`)
+    }
   }
 
   console.log(`\nMake sure MultiClaude is running: multiclaude start`)


### PR DESCRIPTION
Documents the tmux worker runtime backend merged in #84 — the piece that was dropped from that run.

## Task included
- **docs-tmux**: Documents the tmux backend in the repo docs — how to select it (workerRuntime: "tmux" in .multiclaude.json), how workers run inside mc-<taskId> tmux windows via the backend seam instead of detached subprocesses, how to attach (tmux attach, reusing the current $TMUX session or the detached "multiclaude" session), the capture-pane peek / send-steer supervision model surfaced in the TUI and web dashboard, and busy-footer detection in the stuck-watcher. Includes a "Testing the tmux backend" section covering the vitest files and the manual attach walkthrough.

Follow-up to #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
