### PR TITLE
Web UI: dependency graph visualization for task views

### DIFF
--- a/src/web/public/dag-graph.js
+++ b/src/web/public/dag-graph.js
@@ -1,0 +1,318 @@
+/**
+ * dag-graph.js — Standalone SVG task-dependency graph renderer.
+ *
+ * Usage:
+ *   renderDag(container, tasks, edges [, options])
+ *
+ *   container  HTMLElement to render into
+ *   tasks      Array of { id, title, status }
+ *   edges      Array of { from_task, to_task }  (from = dependency, to = dependent)
+ *   options    Optional layout overrides (nodeWidth, nodeHeight, hGap, vGap, margin)
+ *
+ * Exposes window.renderDag when loaded via <script src>.
+ */
+(function (global) {
+  'use strict';
+
+  var _dagCounter = 0;
+
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  var STATUS_COLORS = {
+    pending:     { fill: '#2a2a4e', stroke: '#555',    text: '#888' },
+    in_progress: { fill: '#1e1e5e', stroke: '#7c83fd', text: '#7c83fd' },
+    done:        { fill: '#14532d', stroke: '#4ade80', text: '#4ade80' },
+    failed:      { fill: '#450a0a', stroke: '#f87171', text: '#f87171' },
+    cancelled:   { fill: '#1c1c1c', stroke: '#444',    text: '#555' },
+  };
+
+  /**
+   * Render a task-dependency DAG as SVG.
+   *
+   * Arrows run left-to-right from dependency to dependent.
+   * Hover or click a node to highlight its connected edges and neighbours;
+   * click again (or click the SVG background) to clear the selection.
+   */
+  function renderDag(container, tasks, edges, options) {
+    if (!container || !tasks || tasks.length === 0) {
+      if (container) container.style.display = 'none';
+      return;
+    }
+    container.style.display = 'block';
+
+    var opts = options || {};
+    var NW = opts.nodeWidth  !== undefined ? opts.nodeWidth  : 180;
+    var NH = opts.nodeHeight !== undefined ? opts.nodeHeight : 50;
+    var HG = opts.hGap      !== undefined ? opts.hGap      : 80;
+    var VG = opts.vGap      !== undefined ? opts.vGap      : 14;
+    var M  = opts.margin    !== undefined ? opts.margin    : 24;
+
+    // Unique prefix so multiple graphs on one page don't share marker IDs
+    var uid = 'dag' + (++_dagCounter);
+
+    // Index tasks
+    var taskById = {};
+    tasks.forEach(function (t) { taskById[t.id] = t; });
+
+    // Build incoming-deps map: taskId -> [from_task_ids that must finish first]
+    var inDeps = {};
+    tasks.forEach(function (t) { inDeps[t.id] = []; });
+    var validEdges = (edges || []).filter(function (e) {
+      return taskById[e.from_task] && taskById[e.to_task];
+    });
+    validEdges.forEach(function (e) {
+      if (inDeps[e.to_task] !== undefined) {
+        inDeps[e.to_task].push(e.from_task);
+      }
+    });
+
+    // Topological levels (cycle guard: if a cycle is detected, treat level as 0)
+    var levels = {};
+    var visiting = {};
+    function computeLevel(id) {
+      if (levels[id] !== undefined) return levels[id];
+      if (visiting[id]) { levels[id] = 0; return 0; }
+      visiting[id] = true;
+      var deps = inDeps[id] || [];
+      if (deps.length === 0) {
+        levels[id] = 0;
+      } else {
+        var max = 0;
+        for (var i = 0; i < deps.length; i++) {
+          var l = computeLevel(deps[i]);
+          if (l + 1 > max) max = l + 1;
+        }
+        levels[id] = max;
+      }
+      visiting[id] = false;
+      return levels[id];
+    }
+    tasks.forEach(function (t) { computeLevel(t.id); });
+
+    // Group into waves (columns) by level
+    var maxLevel = 0;
+    tasks.forEach(function (t) { if (levels[t.id] > maxLevel) maxLevel = levels[t.id]; });
+    var waves = [];
+    for (var w = 0; w <= maxLevel; w++) waves.push([]);
+    tasks.forEach(function (t) { waves[levels[t.id]].push(t); });
+
+    // SVG canvas size
+    var svgW = M * 2 + waves.length * NW + (waves.length - 1) * HG;
+    var maxWaveH = 0;
+    waves.forEach(function (wave) {
+      var h = wave.length * NH + Math.max(0, wave.length - 1) * VG;
+      if (h > maxWaveH) maxWaveH = h;
+    });
+    var svgH = M * 2 + maxWaveH;
+
+    // Node centre positions
+    var pos = {};
+    waves.forEach(function (wave, wi) {
+      var waveH = wave.length * NH + Math.max(0, wave.length - 1) * VG;
+      var startY = M + (maxWaveH - waveH) / 2;
+      wave.forEach(function (t, ti) {
+        var x = M + wi * (NW + HG);
+        var y = startY + ti * (NH + VG);
+        pos[t.id] = { x: x, y: y, cx: x + NW / 2, cy: y + NH / 2 };
+      });
+    });
+
+    // Build SVG markup
+    var parts = [];
+    parts.push(
+      '<svg xmlns="http://www.w3.org/2000/svg"' +
+      ' width="' + svgW + '" height="' + svgH + '"' +
+      ' style="display:block;cursor:default" data-dag-root="1">'
+    );
+
+    // Arrow markers: normal, dimmed, highlighted
+    parts.push('<defs>');
+    // Normal arrow — visible indigo tip
+    parts.push(
+      '<marker id="' + uid + '-arr"' +
+      ' markerWidth="10" markerHeight="7" refX="10" refY="3.5"' +
+      ' orient="auto" markerUnits="userSpaceOnUse">' +
+      '<polygon points="0 0, 10 3.5, 0 7" fill="#7c83fd"/>' +
+      '</marker>'
+    );
+    // Dimmed arrow — almost invisible
+    parts.push(
+      '<marker id="' + uid + '-arr-dim"' +
+      ' markerWidth="10" markerHeight="7" refX="10" refY="3.5"' +
+      ' orient="auto" markerUnits="userSpaceOnUse">' +
+      '<polygon points="0 0, 10 3.5, 0 7" fill="#333"/>' +
+      '</marker>'
+    );
+    // Highlighted arrow — bright white, slightly larger
+    parts.push(
+      '<marker id="' + uid + '-arr-hi"' +
+      ' markerWidth="12" markerHeight="8" refX="12" refY="4"' +
+      ' orient="auto" markerUnits="userSpaceOnUse">' +
+      '<polygon points="0 0, 12 4, 0 8" fill="#fff"/>' +
+      '</marker>'
+    );
+    parts.push('</defs>');
+
+    // Edges drawn first so they appear behind nodes.
+    // Direction: from_task (dependency) → to_task (dependent), left-to-right.
+    validEdges.forEach(function (e) {
+      var s = pos[e.from_task], d = pos[e.to_task];
+      if (!s || !d) return;
+      // Exit from right-centre of source, enter left-centre of destination
+      var x1 = s.x + NW;
+      var y1 = s.cy;
+      var x2 = d.x;
+      var y2 = d.cy;
+      var midX = (x1 + x2) / 2;
+      parts.push(
+        '<path class="dag-edge"' +
+        ' data-from="' + escapeHtml(e.from_task) + '"' +
+        ' data-to="' + escapeHtml(e.to_task) + '"' +
+        ' d="M' + x1 + ',' + y1 +
+        ' C' + midX + ',' + y1 + ' ' + midX + ',' + y2 + ' ' + x2 + ',' + y2 + '"' +
+        ' fill="none"' +
+        ' stroke="#7c83fd" stroke-width="1.5" stroke-opacity="0.55"' +
+        ' marker-end="url(#' + uid + '-arr)"/>'
+      );
+    });
+
+    // Nodes
+    tasks.forEach(function (t) {
+      var p = pos[t.id];
+      if (!p) return;
+      var c = STATUS_COLORS[t.status] || STATUS_COLORS.pending;
+      var raw = t.title || t.id;
+      // Truncate long titles with ellipsis
+      var label = raw.length > 22 ? raw.slice(0, 21) + '…' : raw;
+      var statusText = (t.status || 'pending').replace(/_/g, ' ');
+
+      parts.push(
+        '<g class="dag-node" data-task-id="' + escapeHtml(t.id) + '" style="cursor:pointer">'
+      );
+      // Native SVG tooltip (browser shows on hover after a short delay)
+      parts.push(
+        '<title>' + escapeHtml(raw) + ' — ' + escapeHtml(statusText) + '</title>'
+      );
+      parts.push(
+        '<rect x="' + p.x + '" y="' + p.y + '"' +
+        ' width="' + NW + '" height="' + NH + '" rx="5"' +
+        ' fill="' + c.fill + '" stroke="' + c.stroke + '" stroke-width="1.5"/>'
+      );
+      parts.push(
+        '<text x="' + p.cx + '" y="' + (p.cy - 6) + '"' +
+        ' text-anchor="middle"' +
+        ' fill="' + c.text + '"' +
+        ' font-family="\'Courier New\',monospace" font-size="11">' +
+        escapeHtml(label) + '</text>'
+      );
+      parts.push(
+        '<text x="' + p.cx + '" y="' + (p.cy + 11) + '"' +
+        ' text-anchor="middle"' +
+        ' fill="' + c.text + '"' +
+        ' font-family="\'Courier New\',monospace" font-size="10" opacity="0.7">' +
+        escapeHtml(statusText) + '</text>'
+      );
+      parts.push('</g>');
+    });
+
+    parts.push('</svg>');
+    container.innerHTML = parts.join('');
+
+    // ---- Interactivity ----
+    var svgEl   = container.querySelector('[data-dag-root]');
+    var nodeEls = container.querySelectorAll('.dag-node');
+    var edgeEls = container.querySelectorAll('.dag-edge');
+    var activeNodeId = null;
+
+    // Pre-compute adjacency sets for O(1) neighbour lookup
+    var neighbors = {};   // taskId -> Set of adjacent task ids
+    var connEdges  = {};  // taskId -> Set of connected edge elements
+    tasks.forEach(function (t) {
+      neighbors[t.id] = {};   // plain object used as Set
+      connEdges[t.id]  = [];
+    });
+    edgeEls.forEach(function (el) {
+      var from = el.getAttribute('data-from');
+      var to   = el.getAttribute('data-to');
+      if (neighbors[from]) { neighbors[from][to] = true; connEdges[from].push(el); }
+      if (neighbors[to])   { neighbors[to][from] = true; connEdges[to].push(el); }
+    });
+
+    function applyHighlight(tid) {
+      var nbrs = neighbors[tid] || {};
+      var myEdges = connEdges[tid] || [];
+
+      nodeEls.forEach(function (el) {
+        var etid = el.getAttribute('data-task-id');
+        el.style.opacity = (etid === tid || nbrs[etid]) ? '1' : '0.15';
+      });
+
+      edgeEls.forEach(function (el) {
+        var isConn = false;
+        for (var i = 0; i < myEdges.length; i++) {
+          if (myEdges[i] === el) { isConn = true; break; }
+        }
+        if (isConn) {
+          el.style.strokeOpacity = '1';
+          el.style.stroke = '#fff';
+          el.setAttribute('marker-end', 'url(#' + uid + '-arr-hi)');
+        } else {
+          el.style.strokeOpacity = '0.08';
+          el.style.stroke = '#444';
+          el.setAttribute('marker-end', 'url(#' + uid + '-arr-dim)');
+        }
+      });
+    }
+
+    function clearHighlight() {
+      nodeEls.forEach(function (el) { el.style.opacity = '1'; });
+      edgeEls.forEach(function (el) {
+        el.style.strokeOpacity = '0.55';
+        el.style.stroke = '#7c83fd';
+        el.setAttribute('marker-end', 'url(#' + uid + '-arr)');
+      });
+    }
+
+    nodeEls.forEach(function (el) {
+      var tid = el.getAttribute('data-task-id');
+
+      el.addEventListener('mouseenter', function () {
+        if (!activeNodeId) applyHighlight(tid);
+      });
+
+      el.addEventListener('mouseleave', function () {
+        if (!activeNodeId) clearHighlight();
+      });
+
+      el.addEventListener('click', function (ev) {
+        ev.stopPropagation();
+        if (activeNodeId === tid) {
+          activeNodeId = null;
+          clearHighlight();
+        } else {
+          activeNodeId = tid;
+          applyHighlight(tid);
+        }
+      });
+    });
+
+    // Click SVG background to deselect
+    if (svgEl) {
+      svgEl.addEventListener('click', function () {
+        if (activeNodeId) {
+          activeNodeId = null;
+          clearHighlight();
+        }
+      });
+    }
+  }
+
+  global.renderDag = renderDag;
+
+})(typeof window !== 'undefined' ? window : this);

--- a/src/web/public/run.html
+++ b/src/web/public/run.html
@@ -124,6 +124,7 @@
     </thead>
     <tbody id="tasks"></tbody>
   </table>
+  <script src="/dag-graph.js"></script>
   <script>
     const openPanels = new Set()
     // 'logs' or 'pane' — default tab per task
@@ -290,100 +291,6 @@
       if (latestData) renderTasks(latestData)
     }
 
-    function renderDag(tasks, edges) {
-      const container = document.getElementById('dag-container')
-      if (!tasks || tasks.length === 0) { container.style.display = 'none'; return }
-      container.style.display = 'block'
-
-      const taskById = {}
-      tasks.forEach(t => { taskById[t.id] = t })
-
-      // Build incoming-deps map: taskId -> [from_task_ids]
-      const inDeps = {}
-      tasks.forEach(t => { inDeps[t.id] = [] })
-      edges.forEach(e => {
-        if (inDeps[e.to_task] !== undefined && taskById[e.from_task]) {
-          inDeps[e.to_task].push(e.from_task)
-        }
-      })
-
-      // Compute topological level for each task
-      const levels = {}
-      const visiting = new Set()
-      function computeLevel(id) {
-        if (levels[id] !== undefined) return levels[id]
-        if (visiting.has(id)) { levels[id] = 0; return 0 } // cycle guard
-        visiting.add(id)
-        const deps = inDeps[id] || []
-        levels[id] = deps.length === 0 ? 0 : Math.max(...deps.map(d => computeLevel(d))) + 1
-        visiting.delete(id)
-        return levels[id]
-      }
-      tasks.forEach(t => computeLevel(t.id))
-
-      // Group tasks into waves by level
-      const maxLevel = Math.max(...tasks.map(t => levels[t.id]))
-      const waves = []
-      for (let i = 0; i <= maxLevel; i++) waves.push([])
-      tasks.forEach(t => waves[levels[t.id]].push(t))
-
-      // Layout constants
-      const NW = 180, NH = 50, HG = 72, VG = 14, M = 20
-
-      const svgW = M * 2 + waves.length * NW + (waves.length - 1) * HG
-      const maxWaveH = Math.max(...waves.map(w => w.length * NH + Math.max(0, w.length - 1) * VG))
-      const svgH = M * 2 + maxWaveH
-
-      // Compute node center positions
-      const pos = {}
-      waves.forEach((wave, wi) => {
-        const waveH = wave.length * NH + Math.max(0, wave.length - 1) * VG
-        const startY = M + (maxWaveH - waveH) / 2
-        wave.forEach((t, ti) => {
-          const x = M + wi * (NW + HG)
-          const y = startY + ti * (NH + VG)
-          pos[t.id] = { x, y, cx: x + NW / 2, cy: y + NH / 2 }
-        })
-      })
-
-      // Status style map
-      const SC = {
-        pending:     { fill: '#2a2a4e', stroke: '#555',    text: '#888' },
-        in_progress: { fill: '#1e1e5e', stroke: '#7c83fd', text: '#7c83fd' },
-        done:        { fill: '#14532d', stroke: '#4ade80', text: '#4ade80' },
-        failed:      { fill: '#450a0a', stroke: '#f87171', text: '#f87171' },
-        cancelled:   { fill: '#1c1c1c', stroke: '#444',    text: '#555' },
-      }
-
-      let svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${svgW}" height="${svgH}" style="display:block">`
-      svg += `<defs><marker id="dag-arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto"><polygon points="0 0,10 3.5,0 7" fill="#555"/></marker></defs>`
-
-      // Draw edges first (behind nodes)
-      edges.forEach(e => {
-        const s = pos[e.from_task], d = pos[e.to_task]
-        if (!s || !d) return
-        const x1 = s.x + NW, y1 = s.cy
-        const x2 = d.x, y2 = d.cy
-        const midX = (x1 + x2) / 2
-        svg += `<path d="M${x1},${y1} C${midX},${y1} ${midX},${y2} ${x2},${y2}" fill="none" stroke="#555" stroke-width="1.5" marker-end="url(#dag-arrow)"/>`
-      })
-
-      // Draw nodes
-      tasks.forEach(t => {
-        const p = pos[t.id]
-        if (!p) return
-        const c = SC[t.status] || SC.pending
-        const raw = t.title || t.id
-        const label = raw.length > 22 ? raw.slice(0, 21) + '\u2026' : raw
-        svg += `<rect x="${p.x}" y="${p.y}" width="${NW}" height="${NH}" rx="5" fill="${c.fill}" stroke="${c.stroke}" stroke-width="1.5"/>`
-        svg += `<text x="${p.cx}" y="${p.cy - 6}" text-anchor="middle" fill="${c.text}" font-family="'Courier New',monospace" font-size="11">${escapeHtml(label)}</text>`
-        svg += `<text x="${p.cx}" y="${p.cy + 11}" text-anchor="middle" fill="${c.text}" font-family="'Courier New',monospace" font-size="10" opacity="0.7">${t.status.replace('_', ' ')}</text>`
-      })
-
-      svg += '</svg>'
-      container.innerHTML = svg
-    }
-
     function renderTasks(tasks) {
       latestData = tasks
       document.getElementById('running').textContent = tasks.filter(t => t.status === 'in_progress').length
@@ -526,7 +433,7 @@
         if (!resp.ok) { document.getElementById('run-title').textContent = 'Run not found'; return }
         const { run } = await resp.json()
         dagEdges = run.edges || []
-        if (latestData) renderDag(latestData, dagEdges)
+        if (latestData) renderDag(document.getElementById('dag-container'), latestData, dagEdges)
         runBudgetUsd = run.budget_usd ?? null
         if (runBudgetUsd != null) {
           document.getElementById('cost-label').textContent = `Cost / $${runBudgetUsd.toFixed(2)} budget`
@@ -574,7 +481,7 @@
       // Skip task-table re-render if only logs changed (live streams handle that)
       if (JSON.stringify(latestData) !== JSON.stringify(runTasks)) {
         renderTasks(runTasks)
-        renderDag(runTasks, dagEdges)
+        renderDag(document.getElementById('dag-container'), runTasks, dagEdges)
       }
     }
   </script>

--- a/src/web/public/tasks.html
+++ b/src/web/public/tasks.html
@@ -65,7 +65,11 @@
     .cost-val { color: #34d399; }
     .duration { color: #94a3b8; }
     .token-detail { font-size: 11px; color: #666; margin-top: 2px; }
+    .dag-section { margin-bottom: 24px; }
+    .dag-section h2 { font-size: 13px; color: #555; margin-bottom: 10px; text-transform: uppercase; letter-spacing: 0.05em; }
+    #dag-container { overflow: auto; background: #0d0d1f; border-radius: 8px; padding: 16px; max-height: 500px; }
   </style>
+  <script src="/dag-graph.js"></script>
 </head>
 <body>
   <h1>MultiClaude</h1>
@@ -81,6 +85,10 @@
     <div class="stat pending"><div class="count" id="pending">0</div><div class="label">Pending</div></div>
     <div class="stat tokens"><div class="count" id="total-tokens">0</div><div class="label">Tokens</div></div>
     <div class="stat cost"><div class="count" id="total-cost">$0</div><div class="label">Cost</div></div>
+  </div>
+  <div class="dag-section" id="dag-section" style="display:none">
+    <h2>Task Graph</h2>
+    <div id="dag-container"></div>
   </div>
   <table>
     <thead>
@@ -310,6 +318,17 @@
       }
     }
 
+    function updateDag(tasks, edges) {
+      const dagSection = document.getElementById('dag-section')
+      const dagContainer = document.getElementById('dag-container')
+      if (!tasks || tasks.length === 0 || !edges || edges.length === 0) {
+        dagSection.style.display = 'none'
+        return
+      }
+      dagSection.style.display = ''
+      renderDag(dagContainer, tasks, edges)
+    }
+
     const es = new EventSource('/api/events')
     es.onmessage = ({ data }) => {
       const newData = JSON.parse(data)
@@ -317,6 +336,7 @@
       const tasksChanged = !latestData || JSON.stringify(newData.tasks) !== JSON.stringify(latestData.tasks)
       if (tasksChanged) render(newData)
       else latestData = newData
+      updateDag(newData.tasks, newData.edges)
     }
   </script>
 </body>


### PR DESCRIPTION
Adds graphical dependency visualization (nodes connected by arrows) so users can see how tasks depend on one another, across both task views.

## Tasks included
- **dag-graph-module**: New shared, framework-free module `src/web/public/dag-graph.js` that renders an SVG task-dependency graph — lays nodes out in topological dependency waves, draws curved directional arrows from each dependency to its dependent, colors nodes by status, plus click/hover-to-highlight a node's connected edges & neighbors and full-title tooltips.
- **run-page-use-module**: Rewired the run detail page (`run.html`) to load the shared module and call its renderer, removing the duplicated inline `renderDag` so there's a single source of truth; keeps live SSE updates and adds the new interactivity.
- **all-tasks-page-graph**: Added a "Task Graph" section to the previously flat All Tasks page (`tasks.html`), rendering the dependency graph above the table from the global `edges` in the SSE snapshot, updating live and hiding when there are no tasks/edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)