### PR TITLE
Fix: run page dependency graph reads wrong edges field

### DIFF
--- a/src/web/public/run.html
+++ b/src/web/public/run.html
@@ -431,8 +431,8 @@
       try {
         const resp = await fetch(`/api/runs/${runId}`)
         if (!resp.ok) { document.getElementById('run-title').textContent = 'Run not found'; return }
-        const { run } = await resp.json()
-        dagEdges = run.edges || []
+        const { run, edges } = await resp.json()
+        dagEdges = edges || []
         if (latestData) renderDag(document.getElementById('dag-container'), latestData, dagEdges)
         runBudgetUsd = run.budget_usd ?? null
         if (runBudgetUsd != null) {


### PR DESCRIPTION
The run detail page's dependency graph rendered all task nodes in a single column with no arrows because `loadRunMeta()` read edges from the wrong field.

The API `GET /api/runs/:id` (`src/web/server.ts:83`) returns `{ run, tasks, edges }` — `edges` is a **top-level sibling** of `run`, not `run.edges`. The page read `run.edges` (always `undefined`), so `dagEdges` was always empty and the graph got no dependency data.

## Fix

```diff
- const { run } = await resp.json()
- dagEdges = run.edges || []
+ const { run, edges } = await resp.json()
+ dagEdges = edges || []
```

One-line data-wiring fix in `src/web/public/run.html`. This bug pre-existed the recent graph feature work (the wiring was carried forward unchanged). The All Tasks page was unaffected — it reads `edges` correctly from the SSE snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
