### PR TITLE
Per-task reasoning effort selection (effort alongside model)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,8 +218,8 @@ Identify dependencies — which tasks must complete before others can start. The
 plan_dag({
   tasks: [
     { id: "rename-fields", title: "Rename DB columns to camelCase", ticket: "#42", model: "haiku" },
-    { id: "implement-auth", title: "Implement OAuth2 login flow", ticket: "#42", model: "sonnet" },
-    { id: "design-schema", title: "Design multi-tenant data model", ticket: "#45", model: "opus", dependsOn: [] },
+    { id: "implement-auth", title: "Implement OAuth2 login flow", ticket: "#42", model: "sonnet", effort: "high" },
+    { id: "design-schema", title: "Design multi-tenant data model", ticket: "#45", model: "opus", effort: "extra", dependsOn: [] },
     { id: "update-schema-docs", title: "Update docs for new schema", ticket: "#45", model: "haiku", dependsOn: ["design-schema"] }
   ],
   cwd: "/path/to/project",
@@ -313,6 +313,24 @@ If no model is specified, workers default to **sonnet**.
 
 ---
 
+## Effort Selection
+
+When planning tasks, assign the appropriate reasoning effort based on complexity. Use the `effort` field in each task:
+
+| Level | Effort | Use when |
+|-------|--------|----------|
+| low | low | Mechanical tasks: reformatting files, renaming symbols, writing boilerplate, adding type annotations, updating config files, moving files, generating fixtures/mocks |
+| medium | medium | Standard mechanical work that requires some analysis: reviewing code patterns, understanding constraints, making decisions between obvious options |
+| high | high | Standard development: implementing features, writing tests, fixing bugs, refactoring, code review **(DEFAULT)** |
+| extra | extra | Complex work: ambitious features, novel algorithms, performance optimization, tricky refactors where mistakes are costly |
+| max | max | Highest-stakes complexity: architecture decisions, security-critical code, legal/compliance-critical work, tasks where errors are very expensive to undo |
+
+Effort is set independently of `model` — a complex task might use `model: "haiku"` (simple implementation) with `effort: "high"` (complex reasoning), or `model: "opus"` (most capable) with `effort: "low"` (mechanical work).
+
+If no effort is specified, workers default to **high**.
+
+---
+
 ## ⚠️ CRITICAL: Never Do Workers' Jobs Yourself
 
 **You MUST NOT use the built-in `Agent` subagent (previously called `Task`), `Bash`, `Write`, `Edit`, or any other tool to implement tasks.** You are a coordinator, not an implementer.
@@ -342,7 +360,7 @@ The spawner watcher **automatically retries** failed tasks up to `max_retries` t
 | Tool | When to use |
 |---|---|
 | `create_run(title, cwd, external_ref?)` | Before `plan_dag` when handling named tickets/features — creates a run and returns `run_id`. For multiple tickets, create ONE run with a combined title |
-| `plan_dag(epic)` | Once per decomposition — creates the DAG and returns ASCII visualization. Always pass `cwd` and optional `run_id`. Use the `ticket` field in tasks to label which issue each task belongs to (for multi-ticket runs) and `dependsOn` for cross-ticket dependencies |
+| `plan_dag(epic)` | Once per decomposition — creates the DAG and returns ASCII visualization. Always pass `cwd` and optional `run_id`. Use the `ticket` field in tasks to label which issue each task belongs to (for multi-ticket runs), `model` for model tier, `effort` for reasoning effort, and `dependsOn` for cross-ticket dependencies |
 | `AskUserQuestion` | Step 3 plan approval — show visualization and ask Proceed/Revise |
 | `get_system_status(include_done?)` | Instant snapshot — returns only active tasks by default (include_done=true to see all); always includes active_count and done_count |
 | `wait_for_event(timeout_seconds?, include_done?)` | **Monitoring loop** — blocks until something changes, then returns active tasks by default; always includes active_count and done_count |

--- a/prompts/orchestrator.md
+++ b/prompts/orchestrator.md
@@ -82,8 +82,8 @@ Identify dependencies — which tasks must complete before others can start. The
 plan_dag({
   tasks: [
     { id: "rename-fields", title: "Rename DB columns to camelCase", ticket: "#42", model: "haiku" },
-    { id: "implement-auth", title: "Implement OAuth2 login flow", ticket: "#42", model: "sonnet" },
-    { id: "design-schema", title: "Design multi-tenant data model", ticket: "#45", model: "opus", dependsOn: [] },
+    { id: "implement-auth", title: "Implement OAuth2 login flow", ticket: "#42", model: "sonnet", effort: "high" },
+    { id: "design-schema", title: "Design multi-tenant data model", ticket: "#45", model: "opus", effort: "extra", dependsOn: [] },
     { id: "update-schema-docs", title: "Update docs for new schema", ticket: "#45", model: "haiku", dependsOn: ["design-schema"] }
   ],
   cwd: "/path/to/project",
@@ -177,6 +177,24 @@ If no model is specified, workers default to **sonnet**.
 
 ---
 
+## Effort Selection
+
+When planning tasks, assign the appropriate reasoning effort based on complexity. Use the `effort` field in each task:
+
+| Level | Effort | Use when |
+|-------|--------|----------|
+| low | low | Mechanical tasks: reformatting files, renaming symbols, writing boilerplate, adding type annotations, updating config files, moving files, generating fixtures/mocks |
+| medium | medium | Standard mechanical work that requires some analysis: reviewing code patterns, understanding constraints, making decisions between obvious options |
+| high | high | Standard development: implementing features, writing tests, fixing bugs, refactoring, code review **(DEFAULT)** |
+| extra | extra | Complex work: ambitious features, novel algorithms, performance optimization, tricky refactors where mistakes are costly |
+| max | max | Highest-stakes complexity: architecture decisions, security-critical code, legal/compliance-critical work, tasks where errors are very expensive to undo |
+
+Effort is set independently of `model` — a complex task might use `model: "haiku"` (simple implementation) with `effort: "high"` (complex reasoning), or `model: "opus"` (most capable) with `effort: "low"` (mechanical work).
+
+If no effort is specified, workers default to **high**.
+
+---
+
 ## ⚠️ CRITICAL: Never Do Workers' Jobs Yourself
 
 **You MUST NOT use the built-in `Agent` subagent (previously called `Task`), `Bash`, `Write`, `Edit`, or any other tool to implement tasks.** You are a coordinator, not an implementer.
@@ -206,7 +224,7 @@ The spawner watcher **automatically retries** failed tasks up to `max_retries` t
 | Tool | When to use |
 |---|---|
 | `create_run(title, cwd, external_ref?)` | Before `plan_dag` when handling named tickets/features — creates a run and returns `run_id`. For multiple tickets, create ONE run with a combined title |
-| `plan_dag(epic)` | Once per decomposition — creates the DAG and returns ASCII visualization. Always pass `cwd` and optional `run_id`. Use the `ticket` field in tasks to label which issue each task belongs to (for multi-ticket runs) and `dependsOn` for cross-ticket dependencies |
+| `plan_dag(epic)` | Once per decomposition — creates the DAG and returns ASCII visualization. Always pass `cwd` and optional `run_id`. Use the `ticket` field in tasks to label which issue each task belongs to (for multi-ticket runs), `model` for model tier, `effort` for reasoning effort, and `dependsOn` for cross-ticket dependencies |
 | `AskUserQuestion` | Step 3 plan approval — show visualization and ask Proceed/Revise |
 | `get_system_status(include_done?)` | Instant snapshot — returns only active tasks by default (include_done=true to see all); always includes active_count and done_count |
 | `wait_for_event(timeout_seconds?, include_done?)` | **Monitoring loop** — blocks until something changes, then returns active tasks by default; always includes active_count and done_count |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -127,6 +127,7 @@ function startSpawnerWatcher(
         taskTitle: task.title,
         taskDescription: task.description ?? undefined,
         model: task.model,
+        effort: task.effort ?? undefined,
         agentId: agent.id,
         worktreePath: agent.cwd,
         mcpConfigPath,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -106,6 +106,7 @@ function createOrchestratorMcp(db: Database.Database): McpServer {
               title: z.string(),
               description: z.string().optional(),
               model: z.enum(['haiku', 'sonnet', 'opus']).optional().describe('Model to use for this task (default: sonnet)'),
+              effort: z.enum(['low', 'medium', 'high', 'extra', 'max']).optional().describe('Reasoning effort level (default: high). Use lower for mechanical tasks, higher for complex/high-stakes tasks.'),
               ticket: z.string().optional().describe('Ticket/issue identifier to group tasks in the web UI (e.g. "PROJ-123")'),
               dependsOn: z.array(z.string()),
             }))

--- a/src/server/state/db.ts
+++ b/src/server/state/db.ts
@@ -28,6 +28,7 @@ export function createDb(path: string = './multiclaude.db'): Database.Database {
       description TEXT,
       status TEXT NOT NULL DEFAULT 'pending',
       model TEXT NOT NULL DEFAULT 'sonnet',
+      effort TEXT NOT NULL DEFAULT 'high',
       retry_count INTEGER NOT NULL DEFAULT 0,
       max_retries INTEGER NOT NULL DEFAULT 3,
       worktree_path TEXT,
@@ -80,6 +81,7 @@ export function createDb(path: string = './multiclaude.db'): Database.Database {
   try { db.exec("ALTER TABLE tasks ADD COLUMN total_tokens INTEGER") } catch { /* already exists */ }
   try { db.exec("ALTER TABLE tasks ADD COLUMN run_id TEXT REFERENCES runs(id)") } catch { /* already exists */ }
   try { db.exec("ALTER TABLE tasks ADD COLUMN model TEXT NOT NULL DEFAULT 'sonnet'") } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE tasks ADD COLUMN effort TEXT NOT NULL DEFAULT 'high'") } catch { /* already exists */ }
   try { db.exec("ALTER TABLE tasks ADD COLUMN repo_path TEXT") } catch { /* already exists */ }
   try { db.exec("ALTER TABLE tasks ADD COLUMN cost_usd REAL") } catch { /* already exists */ }
   try { db.exec("ALTER TABLE tasks ADD COLUMN ticket TEXT") } catch { /* already exists */ }

--- a/src/server/state/tasks.ts
+++ b/src/server/state/tasks.ts
@@ -8,6 +8,7 @@ export interface Task {
   description: string | null
   status: TaskStatus
   model: string
+  effort: string
   retry_count: number
   max_retries: number
   worktree_path: string | null
@@ -31,6 +32,7 @@ export interface CreateTaskInput {
   title: string
   description?: string
   model?: string
+  effort?: string
   max_retries?: number
   run_id?: string
   ticket?: string
@@ -53,13 +55,14 @@ export interface UpdateTaskInput {
 
 export function createTask(db: Database.Database, input: CreateTaskInput): void {
   db.prepare(`
-    INSERT INTO tasks (id, title, description, model, max_retries, run_id, ticket)
-    VALUES (@id, @title, @description, @model, @max_retries, @run_id, @ticket)
+    INSERT INTO tasks (id, title, description, model, effort, max_retries, run_id, ticket)
+    VALUES (@id, @title, @description, @model, @effort, @max_retries, @run_id, @ticket)
   `).run({
     id: input.id,
     title: input.title,
     description: input.description ?? null,
     model: input.model ?? 'sonnet',
+    effort: input.effort ?? 'high',
     max_retries: input.max_retries ?? 3,
     run_id: input.run_id ?? null,
     ticket: input.ticket ?? null,

--- a/src/server/tools/orchestrator.ts
+++ b/src/server/tools/orchestrator.ts
@@ -13,6 +13,7 @@ export interface EpicTask {
   title: string
   description?: string
   model?: string
+  effort?: string
   ticket?: string
   dependsOn: string[]
 }
@@ -41,7 +42,7 @@ export function handlePlanDag(
     run_id = run.id
   }
   for (const t of epic.tasks) {
-    createTask(db, { id: t.id, title: t.title, description: t.description, model: t.model, run_id, ticket: t.ticket })
+    createTask(db, { id: t.id, title: t.title, description: t.description, model: t.model, effort: t.effort, run_id, ticket: t.ticket })
   }
   for (const t of epic.tasks) {
     for (const dep of t.dependsOn) {

--- a/src/spawner/index.ts
+++ b/src/spawner/index.ts
@@ -18,6 +18,7 @@ export interface SpawnConfig {
   taskTitle: string
   taskDescription?: string
   model?: string
+  effort?: string
   agentId: string
   worktreePath: string
   mcpConfigPath: string
@@ -85,6 +86,9 @@ export function buildWorkerArgs(cfg: SpawnConfig): string[] {
   const modelKey = cfg.model ?? 'sonnet'
   const modelId = MODEL_IDS[modelKey] ?? MODEL_IDS.sonnet
 
+  // Only emit --effort when explicitly set to a non-default value ('high' is Claude Code's default)
+  const effortFlags = (cfg.effort && cfg.effort !== 'high') ? ['--effort', cfg.effort] : []
+
   return [
     '--mcp-config', cfg.mcpConfigPath,
     '--allow-dangerously-skip-permissions',
@@ -93,6 +97,7 @@ export function buildWorkerArgs(cfg: SpawnConfig): string[] {
     ...extraFlags,
     '--output-format', outputFormat,
     '--model', modelId,
+    ...effortFlags,
     prompt,
   ]
 }

--- a/tests/spawner/index.test.ts
+++ b/tests/spawner/index.test.ts
@@ -137,4 +137,71 @@ describe('spawner', () => {
     if (orig === undefined) delete process.env['CLAUDECODE']
     else process.env['CLAUDECODE'] = orig
   })
+
+  it('buildWorkerArgs omits --effort when effort is unset (high is the default)', () => {
+    const cfg: SpawnConfig = {
+      taskId: 'task-1',
+      taskTitle: 'Build auth',
+      agentId: 'w-task-1',
+      worktreePath: '/tmp/mc-task-1',
+      mcpConfigPath: '/tmp/mc-worker-config.json',
+    }
+    const args = buildWorkerArgs(cfg)
+    expect(args).not.toContain('--effort')
+  })
+
+  it('buildWorkerArgs omits --effort when effort is explicitly high (backwards-compatible default)', () => {
+    const cfg: SpawnConfig = {
+      taskId: 'task-1',
+      taskTitle: 'Build auth',
+      effort: 'high',
+      agentId: 'w-task-1',
+      worktreePath: '/tmp/mc-task-1',
+      mcpConfigPath: '/tmp/mc-worker-config.json',
+    }
+    const args = buildWorkerArgs(cfg)
+    expect(args).not.toContain('--effort')
+  })
+
+  it('buildWorkerArgs passes --effort low for low effort', () => {
+    const cfg: SpawnConfig = {
+      taskId: 'task-1',
+      taskTitle: 'Build auth',
+      effort: 'low',
+      agentId: 'w-task-1',
+      worktreePath: '/tmp/mc-task-1',
+      mcpConfigPath: '/tmp/mc-worker-config.json',
+    }
+    const args = buildWorkerArgs(cfg)
+    expect(args).toContain('--effort')
+    expect(args[args.indexOf('--effort') + 1]).toBe('low')
+  })
+
+  it('buildWorkerArgs passes --effort max for max effort', () => {
+    const cfg: SpawnConfig = {
+      taskId: 'task-1',
+      taskTitle: 'Build auth',
+      effort: 'max',
+      agentId: 'w-task-1',
+      worktreePath: '/tmp/mc-task-1',
+      mcpConfigPath: '/tmp/mc-worker-config.json',
+    }
+    const args = buildWorkerArgs(cfg)
+    expect(args).toContain('--effort')
+    expect(args[args.indexOf('--effort') + 1]).toBe('max')
+  })
+
+  it('buildWorkerArgs passes --effort xhigh for xhigh effort', () => {
+    const cfg: SpawnConfig = {
+      taskId: 'task-1',
+      taskTitle: 'Build auth',
+      effort: 'xhigh',
+      agentId: 'w-task-1',
+      worktreePath: '/tmp/mc-task-1',
+      mcpConfigPath: '/tmp/mc-worker-config.json',
+    }
+    const args = buildWorkerArgs(cfg)
+    expect(args).toContain('--effort')
+    expect(args[args.indexOf('--effort') + 1]).toBe('xhigh')
+  })
 })

--- a/tests/state/tasks.test.ts
+++ b/tests/state/tasks.test.ts
@@ -41,4 +41,14 @@ describe('tasks', () => {
   it('returns null for missing task', () => {
     expect(getTask(db, 'nonexistent')).toBeNull()
   })
+
+  it('persists a provided effort value', () => {
+    createTask(db, { id: 'task-1', title: 'Build auth', effort: 'low' })
+    expect(getTask(db, 'task-1')?.effort).toBe('low')
+  })
+
+  it('defaults effort to high when omitted', () => {
+    createTask(db, { id: 'task-1', title: 'Build auth' })
+    expect(getTask(db, 'task-1')?.effort).toBe('high')
+  })
 })

--- a/tests/tools/orchestrator.test.ts
+++ b/tests/tools/orchestrator.test.ts
@@ -68,6 +68,21 @@ describe('orchestrator tools', () => {
     expect(tasks.find(t => t.id === 'c')?.model).toBe('opus')
   })
 
+  it('plan_dag stores effort field on tasks (defaults to high)', () => {
+    const epic = {
+      tasks: [
+        { id: 'a', title: 'Low effort task', effort: 'low', dependsOn: [] },
+        { id: 'b', title: 'Default effort task', dependsOn: [] },
+        { id: 'c', title: 'Max effort task', effort: 'max', dependsOn: [] },
+      ]
+    }
+    handlePlanDag(db, epic)
+    const tasks = db.prepare('SELECT id, effort FROM tasks ORDER BY id').all() as { id: string; effort: string }[]
+    expect(tasks.find(t => t.id === 'a')?.effort).toBe('low')
+    expect(tasks.find(t => t.id === 'b')?.effort).toBe('high')
+    expect(tasks.find(t => t.id === 'c')?.effort).toBe('max')
+  })
+
   it('get_system_status returns tasks, agents, readyTasks, and retriableTasks', () => {
     const status = handleGetSystemStatus(db)
     expect(status).toHaveProperty('tasks')


### PR DESCRIPTION
## Summary

Adds a per-task **reasoning effort** dimension so the orchestrator can tune effort (not just model) to task complexity — addressing the quality regression from every worker defaulting to `high` effort.

Effort flows end-to-end the same way `model` already does:
`plan_dag` schema → `EpicTask` → `handlePlanDag` → `tasks.effort` (DB) → spawner watcher → `claude --effort <level>`.

Valid levels: `low`, `medium`, `high` (default), `extra`, `max`.

## Tasks included

- **effort-data-layer**: Added `effort` column (default `high`) to the `tasks` table with migration; extended the `Task` type, `CreateTaskInput`, and `createTask`.
- **effort-orchestrator-api**: Added optional `effort` enum (`low`/`medium`/`high`/`extra`/`max`) to the `plan_dag` MCP tool schema, `EpicTask` interface, and `handlePlanDag`.
- **effort-spawner**: Threaded `effort` into `SpawnConfig` and worker launch, emitting the `--effort` CLI flag (only for non-default values, keeping existing behavior unchanged).
- **effort-docs**: Added an "Effort Selection" section and updated the `plan_dag` examples + Tools Reference in `CLAUDE.md` and `prompts/orchestrator.md`.
- **effort-tests**: Added coverage for effort persistence (DB), plan_dag storage (DAG), and CLI-arg emission (spawner); full suite verified.

## Guidance

- `low` / `medium` — mechanical tasks (renames, boilerplate, config)
- `high` — standard development (default)
- `extra` / `max` — high-stakes / complex work (architecture, security-critical, novel algorithms)

Set independently of the `model` tier.

🤖 Built via MultiClaude (5 workers, 3 waves).
