### PR TITLE
Fix all open issues (#96, #95, #94, #93, #92, #89, #48)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,8 +294,19 @@ When all tasks in a run are done, workers will have assembled the run integratio
      - **task-id-1**: summary from report_done
      - **task-id-2**: summary from report_done
      ```
-2. Share the PR URL with the user.
-3. **Do not merge** — the user must approve the PR before merging to main.
+
+2. **Closing keywords (CRITICAL):** Append a closing line that automatically closes all referenced issues upon merge. Assemble this mechanically from the distinct `ticket` values on the run's tasks:
+   - Collect all unique issue numbers from task `ticket` fields (e.g. if tasks have `ticket: "#42"`, `"#45"`, `"#42"`, collect `["#42", "#45"]`)
+   - Build the line as: `Closes #42, closes #45` (one `closes` keyword per issue)
+   - **⚠️ The trap:** `Closes #42, #45` closes only #42 — GitHub interprets the comma-separated list as a single reference. You must repeat `closes` for each issue.
+   - **Also note:** Issue numbers in the PR title do NOT close anything — only keywords in the body work.
+   - Append the closing line to the PR body at the end, on its own line(s)
+
+3. After the PR merges, verify that each referenced issue actually closed. If any remain open, the closing keywords may not have been applied correctly — escalate to the user.
+
+4. Share the PR URL with the user.
+
+5. **Do not merge** — the user must approve the PR before merging to main.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,7 @@ plan_dag({
   tasks: [
     { id: "rename-fields", title: "Rename DB columns to camelCase", ticket: "#42", model: "haiku" },
     { id: "implement-auth", title: "Implement OAuth2 login flow", ticket: "#42", model: "sonnet", effort: "high" },
-    { id: "design-schema", title: "Design multi-tenant data model", ticket: "#45", model: "opus", effort: "extra", dependsOn: [] },
+    { id: "design-schema", title: "Design multi-tenant data model", ticket: "#45", model: "opus", effort: "xhigh", dependsOn: [] },
     { id: "update-schema-docs", title: "Update docs for new schema", ticket: "#45", model: "haiku", dependsOn: ["design-schema"] }
   ],
   cwd: "/path/to/project",
@@ -322,7 +322,7 @@ When planning tasks, assign the appropriate reasoning effort based on complexity
 | low | low | Mechanical tasks: reformatting files, renaming symbols, writing boilerplate, adding type annotations, updating config files, moving files, generating fixtures/mocks |
 | medium | medium | Standard mechanical work that requires some analysis: reviewing code patterns, understanding constraints, making decisions between obvious options |
 | high | high | Standard development: implementing features, writing tests, fixing bugs, refactoring, code review **(DEFAULT)** |
-| extra | extra | Complex work: ambitious features, novel algorithms, performance optimization, tricky refactors where mistakes are costly |
+| xhigh | xhigh | Complex work: ambitious features, novel algorithms, performance optimization, tricky refactors where mistakes are costly |
 | max | max | Highest-stakes complexity: architecture decisions, security-critical code, legal/compliance-critical work, tasks where errors are very expensive to undo |
 
 Effort is set independently of `model` — a complex task might use `model: "haiku"` (simple implementation) with `effort: "high"` (complex reasoning), or `model: "opus"` (most capable) with `effort: "low"` (mechanical work).
@@ -338,7 +338,7 @@ When a task has no explicit `effort`, infer one from its title and description:
 | Purely mechanical: rename, reformat, move/rename files, regenerate fixtures/mocks, bump versions, update config, add type annotations, copy boilerplate | **low** |
 | Mechanical but needs light reading: doc updates requiring code inspection, wiring a pre-designed change across a few files, simple choices between obvious options | **medium** |
 | Standard development: implement a feature, write tests, fix a bug, refactor, code review — or whenever signals are mixed or unclear | **high** *(default)* |
-| Complex/ambitious: novel algorithms, non-trivial performance optimization, tricky refactors with wide blast radius, cross-cutting changes | **extra** |
+| Complex/ambitious: novel algorithms, non-trivial performance optimization, tricky refactors with wide blast radius, cross-cutting changes | **xhigh** |
 | Highest-stakes: architecture or data-model design, security-critical or auth/crypto code, concurrency/locking, migrations, anything where mistakes are very expensive to undo | **max** |
 
 **Rule:** an explicit `effort` on a task always overrides this heuristic — the table above only applies when `effort` is absent.
@@ -350,7 +350,7 @@ Effort and model are independent — infer them separately. A few examples:
 | "Rename `user_id` → `userId` in all DB columns" | low | haiku | Pure mechanical rename |
 | "Update README to document the new `effort` field" | medium | haiku | Doc update that requires reading code |
 | "Implement rate limiting on /api/chat" | high | sonnet | Standard feature work **(default)** |
-| "Refactor auth to support multi-tenant token scopes" | extra | sonnet | Wide blast radius, non-trivial design |
+| "Refactor auth to support multi-tenant token scopes" | xhigh | sonnet | Wide blast radius, non-trivial design |
 | "Design migration strategy for splitting the users table" | max | opus | Architecture decision, hard to undo |
 
 ---

--- a/prompts/orchestrator.md
+++ b/prompts/orchestrator.md
@@ -83,7 +83,7 @@ plan_dag({
   tasks: [
     { id: "rename-fields", title: "Rename DB columns to camelCase", ticket: "#42", model: "haiku" },
     { id: "implement-auth", title: "Implement OAuth2 login flow", ticket: "#42", model: "sonnet", effort: "high" },
-    { id: "design-schema", title: "Design multi-tenant data model", ticket: "#45", model: "opus", effort: "extra", dependsOn: [] },
+    { id: "design-schema", title: "Design multi-tenant data model", ticket: "#45", model: "opus", effort: "xhigh", dependsOn: [] },
     { id: "update-schema-docs", title: "Update docs for new schema", ticket: "#45", model: "haiku", dependsOn: ["design-schema"] }
   ],
   cwd: "/path/to/project",
@@ -186,7 +186,7 @@ When planning tasks, assign the appropriate reasoning effort based on complexity
 | low | low | Mechanical tasks: reformatting files, renaming symbols, writing boilerplate, adding type annotations, updating config files, moving files, generating fixtures/mocks |
 | medium | medium | Standard mechanical work that requires some analysis: reviewing code patterns, understanding constraints, making decisions between obvious options |
 | high | high | Standard development: implementing features, writing tests, fixing bugs, refactoring, code review **(DEFAULT)** |
-| extra | extra | Complex work: ambitious features, novel algorithms, performance optimization, tricky refactors where mistakes are costly |
+| xhigh | xhigh | Complex work: ambitious features, novel algorithms, performance optimization, tricky refactors where mistakes are costly |
 | max | max | Highest-stakes complexity: architecture decisions, security-critical code, legal/compliance-critical work, tasks where errors are very expensive to undo |
 
 Effort is set independently of `model` — a complex task might use `model: "haiku"` (simple implementation) with `effort: "high"` (complex reasoning), or `model: "opus"` (most capable) with `effort: "low"` (mechanical work).
@@ -202,7 +202,7 @@ When a task has no explicit `effort`, infer one from its title and description:
 | Purely mechanical: rename, reformat, move/rename files, regenerate fixtures/mocks, bump versions, update config, add type annotations, copy boilerplate | **low** |
 | Mechanical but needs light reading: doc updates requiring code inspection, wiring a pre-designed change across a few files, simple choices between obvious options | **medium** |
 | Standard development: implement a feature, write tests, fix a bug, refactor, code review — or whenever signals are mixed or unclear | **high** *(default)* |
-| Complex/ambitious: novel algorithms, non-trivial performance optimization, tricky refactors with wide blast radius, cross-cutting changes | **extra** |
+| Complex/ambitious: novel algorithms, non-trivial performance optimization, tricky refactors with wide blast radius, cross-cutting changes | **xhigh** |
 | Highest-stakes: architecture or data-model design, security-critical or auth/crypto code, concurrency/locking, migrations, anything where mistakes are very expensive to undo | **max** |
 
 **Rule:** an explicit `effort` on a task always overrides this heuristic — the table above only applies when `effort` is absent.
@@ -214,7 +214,7 @@ Effort and model are independent — infer them separately. A few examples:
 | "Rename `user_id` → `userId` in all DB columns" | low | haiku | Pure mechanical rename |
 | "Update README to document the new `effort` field" | medium | haiku | Doc update that requires reading code |
 | "Implement rate limiting on /api/chat" | high | sonnet | Standard feature work **(default)** |
-| "Refactor auth to support multi-tenant token scopes" | extra | sonnet | Wide blast radius, non-trivial design |
+| "Refactor auth to support multi-tenant token scopes" | xhigh | sonnet | Wide blast radius, non-trivial design |
 | "Design migration strategy for splitting the users table" | max | opus | Architecture decision, hard to undo |
 
 ---

--- a/prompts/orchestrator.md
+++ b/prompts/orchestrator.md
@@ -158,8 +158,19 @@ When all tasks in a run are done, workers will have assembled the run integratio
      - **task-id-1**: summary from report_done
      - **task-id-2**: summary from report_done
      ```
-2. Share the PR URL with the user.
-3. **Do not merge** — the user must approve the PR before merging to main.
+
+2. **Closing keywords (CRITICAL):** Append a closing line that automatically closes all referenced issues upon merge. Assemble this mechanically from the distinct `ticket` values on the run's tasks:
+   - Collect all unique issue numbers from task `ticket` fields (e.g. if tasks have `ticket: "#42"`, `"#45"`, `"#42"`, collect `["#42", "#45"]`)
+   - Build the line as: `Closes #42, closes #45` (one `closes` keyword per issue)
+   - **⚠️ The trap:** `Closes #42, #45` closes only #42 — GitHub interprets the comma-separated list as a single reference. You must repeat `closes` for each issue.
+   - **Also note:** Issue numbers in the PR title do NOT close anything — only keywords in the body work.
+   - Append the closing line to the PR body at the end, on its own line(s)
+
+3. After the PR merges, verify that each referenced issue actually closed. If any remain open, the closing keywords may not have been applied correctly — escalate to the user.
+
+4. Share the PR URL with the user.
+
+5. **Do not merge** — the user must approve the PR before merging to main.
 
 ---
 

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -39,7 +39,8 @@ You have access to the `multiclaude-coord` MCP server with worker-scoped tools.
 
 ## Key Principles
 
-- Work only in your assigned worktree. Do not touch other branches.
+- **CRITICAL: Git isolation is enforced.** Your process environment locks all git operations to your assigned worktree via `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_CEILING_DIRECTORIES`. Do NOT unset or override these environment variables. Do NOT checkout other branches. All commits must land on your task branch only.
+- **Stay in your worktree directory.** Do not `cd` to the parent repository or any other git repository. Your working directory is your worktree path.
 - Write tests before implementation (TDD).
 - Commit frequently with descriptive messages.
 - Do not ask the user questions — you work autonomously. If truly ambiguous, document your assumption in a comment and proceed.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,26 @@ interface AgentRow {
   status: string
 }
 
+/**
+ * Scans a worker log file for non-JSON lines, which are CLI stderr output
+ * (warnings, errors from the claude binary itself rather than Claude's responses).
+ * These surface issues like unrecognised flags so they appear in the task log
+ * without requiring the user to open the log file or tmux pane.
+ */
+function parseCliWarnings(logPath: string): string[] {
+  try {
+    const lines = readFileSync(logPath, 'utf8').split('\n')
+    const result: string[] = []
+    for (const line of lines) {
+      const trimmed = line.trim()
+      if (!trimmed) continue
+      try { JSON.parse(trimmed); continue } catch { /* not JSON — likely CLI stderr */ }
+      result.push(trimmed)
+    }
+    return result
+  } catch { return [] }
+}
+
 function parseTokensFromLog(logPath: string): { input_tokens?: number; output_tokens?: number; total_tokens?: number } {
   try {
     const lines = readFileSync(logPath, 'utf8').trim().split('\n').reverse()
@@ -180,9 +200,18 @@ function startSpawnerWatcher(
           }
         }
         if (agent.task_id) {
-          const tokens = parseTokensFromLog(workerLogPath(agent.id))
+          const logPath = workerLogPath(agent.id)
+          const tokens = parseTokensFromLog(logPath)
           if (tokens.total_tokens !== undefined) {
             updateTask(db, agent.task_id, tokens)
+          }
+          // Surface any CLI stderr warnings (non-JSON lines) to the task log
+          // so issues like invalid flags are visible without reading the log file.
+          const warnings = parseCliWarnings(logPath)
+          for (const warning of warnings) {
+            db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
+              agent.task_id, 'warn', `[claude-cli] ${warning}`
+            )
           }
         }
       })

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { getTask, updateTask, listTasks } from './server/state/tasks.js'
 import { updateAgent } from './server/state/agents.js'
 import { handleSpawnWorker } from './server/tools/orchestrator.js'
 import { checkStuckWorkers } from './spawner/stuck-watcher.js'
+import { killTmuxWindow } from './spawner/tmux.js'
 import { writeFileSync, readFileSync, mkdirSync, rmSync, existsSync } from 'fs'
 import { join } from 'path'
 import { execSync } from 'child_process'
@@ -179,6 +180,8 @@ function startSpawnerWatcher(
             }
           }
         }
+        // Reap the tmux window (worker has exited; window may linger as a dead pane)
+        if (handle.tmuxPane) killTmuxWindow(handle.tmuxPane)
         if (agent.task_id) {
           const tokens = parseTokensFromLog(workerLogPath(agent.id))
           if (tokens.total_tokens !== undefined) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,8 +9,8 @@ import { openWorkerTerminal } from './spawner/terminal.js'
 import { getTask, updateTask, listTasks } from './server/state/tasks.js'
 import { updateAgent } from './server/state/agents.js'
 import { handleSpawnWorker } from './server/tools/orchestrator.js'
-import { checkStuckWorkers } from './spawner/stuck-watcher.js'
-import { killTmuxWindow } from './spawner/tmux.js'
+import { checkStuckWorkers, AGENT_NEVER_STARTED_REASON } from './spawner/stuck-watcher.js'
+import { killTmuxWindow, getChildProcessPid } from './spawner/tmux.js'
 import { writeFileSync, readFileSync, mkdirSync, rmSync, existsSync } from 'fs'
 import { join } from 'path'
 import { execSync } from 'child_process'
@@ -170,6 +170,61 @@ function startSpawnerWatcher(
       }
       if (handle.tmuxPane !== undefined) {
         updateAgent(db, agent.id, { tmux_pane: handle.tmuxPane })
+      }
+
+      // For tmux workers: verify the agent process actually started inside the pane.
+      // The pane shell sends keys but Enter may not land; the pid recorded above is
+      // the pane's shell, not claude. Poll asynchronously so we don't block the
+      // event loop. If no child process appears within ~4s the agent never started.
+      if (handle.tmuxPane !== undefined && handle.pid !== undefined) {
+        const panePid = handle.pid
+        const capturedAgentId = agent.id
+        const capturedTaskId = agent.task_id!
+        const capturedPane = handle.tmuxPane
+
+        let verifyAttempts = 0
+        const maxVerifyAttempts = 5
+        const verifyIntervalMs = 800
+
+        const verifyAgentStarted = () => {
+          // If the agent has already exited or been marked (by onExit/onError), stop.
+          const agentRow = db.prepare('SELECT status FROM agents WHERE id = ?')
+            .get(capturedAgentId) as { status: string } | undefined
+          if (agentRow?.status !== 'spawning') return
+
+          const childPid = getChildProcessPid(panePid)
+
+          if (childPid !== undefined) {
+            // Agent process found — record the actual agent pid, not the shell
+            updateAgent(db, capturedAgentId, { pid: childPid })
+            return
+          }
+
+          verifyAttempts++
+          if (verifyAttempts < maxVerifyAttempts) {
+            setTimeout(verifyAgentStarted, verifyIntervalMs)
+            return
+          }
+
+          // All attempts exhausted — agent process never started
+          const current = db.prepare('SELECT status FROM agents WHERE id = ?')
+            .get(capturedAgentId) as { status: string } | undefined
+          if (current?.status !== 'spawning') return  // already handled
+
+          console.warn(`[spawner] ${AGENT_NEVER_STARTED_REASON} for agent ${capturedAgentId}`)
+          updateAgent(db, capturedAgentId, { status: 'failed' })
+          const t = getTask(db, capturedTaskId)
+          if (t && t.status !== 'done' && t.status !== 'failed') {
+            updateTask(db, capturedTaskId, { status: 'failed' })
+          }
+          db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
+            capturedTaskId, 'error', AGENT_NEVER_STARTED_REASON
+          )
+          killTmuxWindow(capturedPane)
+        }
+
+        // Give the tmux send-keys a moment to execute before first check
+        setTimeout(verifyAgentStarted, 2000)
       }
 
       if (openTerminals) {

--- a/src/git/merge.ts
+++ b/src/git/merge.ts
@@ -4,6 +4,17 @@ import { rm } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
+export class MergeConflictError extends Error {
+  constructor(
+    public readonly taskBranch: string,
+    public readonly integBranch: string,
+    public readonly conflictedFiles: string[],
+  ) {
+    super(`Merge conflict: ${taskBranch} cannot be merged into ${integBranch} — conflicted files: ${conflictedFiles.join(', ')}`)
+    this.name = 'MergeConflictError'
+  }
+}
+
 export const RUN_INTEGRATION_BRANCH = (runId: string) => `mc/run-${runId}`
 const FALLBACK_INTEGRATION_BRANCH = 'mc/integration'
 
@@ -50,8 +61,8 @@ export async function mergeWorktreeBranch(repoPath: string, branch: string, runI
         const nonLockConflicts = conflicted.filter(f => !lockFiles.includes(f))
 
         if (nonLockConflicts.length > 0) {
-          await tmpGit.raw(['merge', '--abort'])
-          throw mergeErr
+          try { await tmpGit.raw(['merge', '--abort']) } catch {}
+          throw new MergeConflictError(branch, integBranch, nonLockConflicts)
         }
 
         // Auto-resolve package lock file add/add conflicts by taking theirs
@@ -65,6 +76,13 @@ export async function mergeWorktreeBranch(repoPath: string, branch: string, runI
     } finally {
       await git.raw(['worktree', 'remove', '--force', tmpDir])
       await rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+    }
+
+    // Verify the task branch is now an ancestor of the integration branch
+    try {
+      await git.raw(['merge-base', '--is-ancestor', branch, integBranch])
+    } catch {
+      throw new Error(`Merge verification failed: ${branch} is not an ancestor of ${integBranch} after merge`)
     }
 
     // Push integration branch to origin so the orchestrator can create a PR

--- a/src/git/merge.ts
+++ b/src/git/merge.ts
@@ -2,7 +2,7 @@ import { simpleGit } from 'simple-git'
 import { mkdtempSync } from 'fs'
 import { rm } from 'fs/promises'
 import { tmpdir } from 'os'
-import { join } from 'path'
+import { join, basename } from 'path'
 
 export class MergeConflictError extends Error {
   constructor(
@@ -22,19 +22,82 @@ function getIntegBranch(runId?: string): string {
   return runId ? RUN_INTEGRATION_BRANCH(runId) : FALLBACK_INTEGRATION_BRANCH
 }
 
+const AUTO_RESOLVABLE_FILES = new Set([
+  'package-lock.json',
+  'package.json',
+  'yarn.lock',
+  'pnpm-lock.yaml',
+  'bun.lockb',
+  'shrinkwrap.json',
+  'npm-shrinkwrap.json',
+  'Gemfile.lock',
+  'Pipfile.lock',
+  'poetry.lock',
+  'composer.lock',
+  'Cargo.lock',
+  'go.sum',
+  'go.mod',
+])
+
+export function isAutoResolvable(filePath: string): boolean {
+  const name = basename(filePath)
+  return AUTO_RESOLVABLE_FILES.has(name) || name.endsWith('.lock')
+}
+
+async function getConflictedFiles(git: ReturnType<typeof simpleGit>): Promise<string[]> {
+  const raw = await git.raw(['diff', '--name-only', '--diff-filter=U'])
+  return raw.trim().split('\n').filter(Boolean)
+}
+
+async function autoResolveConflicts(
+  git: ReturnType<typeof simpleGit>,
+  conflicted: string[],
+  strategy: 'ours' | 'theirs',
+): Promise<string[]> {
+  const resolvable = conflicted.filter(f => isAutoResolvable(f))
+  const unresolvable = conflicted.filter(f => !isAutoResolvable(f))
+
+  if (resolvable.length > 0) {
+    await git.raw(['checkout', `--${strategy}`, ...resolvable])
+    await git.raw(['add', ...resolvable])
+  }
+
+  return unresolvable
+}
+
+async function isAncestorOf(
+  git: ReturnType<typeof simpleGit>,
+  ancestor: string,
+  descendant: string,
+): Promise<boolean> {
+  try {
+    const ancestorSha = (await git.revparse([ancestor])).trim()
+    const descendantSha = (await git.revparse([descendant])).trim()
+    if (ancestorSha === descendantSha) return true
+    const mergeBase = (await git.raw(['merge-base', ancestor, descendant])).trim()
+    return mergeBase === ancestorSha
+  } catch {
+    return false
+  }
+}
+
 export async function ensureIntegrationBranch(repoPath: string, runId?: string): Promise<void> {
   const git = simpleGit(repoPath)
   const branch = getIntegBranch(runId)
   const branches = await git.branchLocal()
   if (!branches.all.includes(branch)) {
-    // Create branch from HEAD without checking it out — safe with uncommitted changes
     await git.raw(['branch', branch, 'HEAD'])
   }
 }
 
 const mergeLocks = new Map<string, Promise<void>>()
 
-export async function mergeWorktreeBranch(repoPath: string, branch: string, runId?: string): Promise<void> {
+export async function mergeWorktreeBranch(
+  repoPath: string,
+  branch: string,
+  runId?: string,
+  taskWorktreePath?: string,
+): Promise<void> {
   const key = getIntegBranch(runId)
   const prev = mergeLocks.get(key) ?? Promise.resolve()
   let resolve!: () => void
@@ -46,7 +109,28 @@ export async function mergeWorktreeBranch(repoPath: string, branch: string, runI
     const git = simpleGit(repoPath)
     const integBranch = key
 
-    // Create a temp worktree on the integration branch so we never touch the main repo's working tree
+    // Step 1: Bring task branch up to date with integration branch.
+    // Merges the integration branch into the task branch so it integrates
+    // against the latest state rather than a stale base.
+    if (taskWorktreePath) {
+      const upToDate = await isAncestorOf(git, integBranch, branch)
+      if (!upToDate) {
+        const taskGit = simpleGit(taskWorktreePath)
+        try {
+          await taskGit.raw(['merge', integBranch, '-m', `update: merge ${integBranch} into ${branch}`])
+        } catch {
+          const conflicted = await getConflictedFiles(taskGit)
+          const unresolvable = await autoResolveConflicts(taskGit, conflicted, 'ours')
+          if (unresolvable.length > 0) {
+            try { await taskGit.raw(['merge', '--abort']) } catch {}
+            throw new MergeConflictError(integBranch, branch, unresolvable)
+          }
+          await taskGit.raw(['commit', '-m', `update: merge ${integBranch} into ${branch}`])
+        }
+      }
+    }
+
+    // Step 2: Merge updated task branch into integration branch
     const tmpDir = mkdtempSync(join(tmpdir(), 'mc-merge-'))
     await git.raw(['worktree', 'add', tmpDir, integBranch])
 
@@ -55,22 +139,14 @@ export async function mergeWorktreeBranch(repoPath: string, branch: string, runI
       try {
         await tmpGit.merge([branch, '--no-ff', '-m', `merge: ${branch} into ${integBranch}`])
       } catch (mergeErr) {
-        const conflictedStr = await tmpGit.raw(['diff', '--name-only', '--diff-filter=U'])
-        const conflicted = conflictedStr.trim().split('\n').filter(Boolean)
-        const lockFiles = ['package-lock.json', 'package.json']
-        const nonLockConflicts = conflicted.filter(f => !lockFiles.includes(f))
+        const conflicted = await getConflictedFiles(tmpGit)
+        const unresolvable = await autoResolveConflicts(tmpGit, conflicted, 'theirs')
 
-        if (nonLockConflicts.length > 0) {
+        if (unresolvable.length > 0) {
           try { await tmpGit.raw(['merge', '--abort']) } catch {}
-          throw new MergeConflictError(branch, integBranch, nonLockConflicts)
+          throw new MergeConflictError(branch, integBranch, unresolvable)
         }
 
-        // Auto-resolve package lock file add/add conflicts by taking theirs
-        const filesToResolve = lockFiles.filter(f => conflicted.includes(f))
-        if (filesToResolve.length > 0) {
-          await tmpGit.raw(['checkout', '--theirs', ...filesToResolve])
-          await tmpGit.raw(['add', ...filesToResolve])
-        }
         await tmpGit.raw(['commit', '-m', `merge: ${branch} into ${integBranch}`])
       }
     } finally {
@@ -79,9 +155,8 @@ export async function mergeWorktreeBranch(repoPath: string, branch: string, runI
     }
 
     // Verify the task branch is now an ancestor of the integration branch
-    try {
-      await git.raw(['merge-base', '--is-ancestor', branch, integBranch])
-    } catch {
+    const merged = await isAncestorOf(git, branch, integBranch)
+    if (!merged) {
       throw new Error(`Merge verification failed: ${branch} is not an ancestor of ${integBranch} after merge`)
     }
 
@@ -89,7 +164,6 @@ export async function mergeWorktreeBranch(repoPath: string, branch: string, runI
     try {
       await git.push('origin', integBranch)
     } catch {
-      // Remote branch may not exist yet — retry with --set-upstream
       try {
         await git.raw(['push', '--set-upstream', 'origin', integBranch])
       } catch {

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -1,13 +1,15 @@
 import { simpleGit } from 'simple-git'
-import { mkdtempSync } from 'fs'
+import { mkdtempSync, readFileSync } from 'fs'
 import { rm } from 'fs/promises'
 import { tmpdir } from 'os'
-import { join } from 'path'
+import { join, isAbsolute, resolve } from 'path'
 
 export interface WorktreeInfo {
   path: string
   branch: string
   taskId: string
+  gitDir: string
+  headSha: string
 }
 
 const STOP_WORDS = new Set(['a', 'an', 'the', 'and', 'or', 'in', 'on', 'at', 'to', 'for', 'of', 'with', 'use', 'using'])
@@ -49,6 +51,17 @@ export function branchNameFromTitle(title: string, taskId?: string): string {
   return `${prefix}/${slug}`
 }
 
+export function readWorktreeGitDir(worktreePath: string): string {
+  const dotGitPath = join(worktreePath, '.git')
+  const content = readFileSync(dotGitPath, 'utf8').trim()
+  const match = content.match(/^gitdir:\s*(.+)$/m)
+  if (!match) {
+    throw new Error(`${dotGitPath} does not contain a valid gitdir reference`)
+  }
+  const gitDir = match[1].trim()
+  return isAbsolute(gitDir) ? gitDir : resolve(worktreePath, gitDir)
+}
+
 export async function createWorktree(repoPath: string, taskId: string, taskTitle?: string, baseBranch?: string): Promise<WorktreeInfo> {
   const branch = taskTitle ? branchNameFromTitle(taskTitle, taskId) : `mc/${taskId}`
   const worktreePath = mkdtempSync(join(tmpdir(), `mc-${taskId}-`))
@@ -68,7 +81,12 @@ export async function createWorktree(repoPath: string, taskId: string, taskTitle
   } else {
     await git.raw(['worktree', 'add', '-b', branch, worktreePath])
   }
-  return { path: worktreePath, branch, taskId }
+
+  const gitDir = readWorktreeGitDir(worktreePath)
+  const worktreeGit = simpleGit(worktreePath)
+  const headSha = (await worktreeGit.revparse(['HEAD'])).trim()
+
+  return { path: worktreePath, branch, taskId, gitDir, headSha }
 }
 
 function parseWorktreePathForBranch(porcelainOutput: string, branch: string): string | null {
@@ -82,7 +100,7 @@ function parseWorktreePathForBranch(porcelainOutput: string, branch: string): st
   return null
 }
 
-export async function removeWorktree(repoPath: string, info: WorktreeInfo): Promise<void> {
+export async function removeWorktree(repoPath: string, info: Pick<WorktreeInfo, 'path' | 'branch'>): Promise<void> {
   const git = simpleGit(repoPath)
   // Silently ignore errors when the worktree is already gone (idempotent)
   await git.raw(['worktree', 'remove', '--force', info.path]).catch(() => {})

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -106,7 +106,10 @@ function createOrchestratorMcp(db: Database.Database): McpServer {
               title: z.string(),
               description: z.string().optional(),
               model: z.enum(['haiku', 'sonnet', 'opus']).optional().describe('Model to use for this task (default: sonnet)'),
-              effort: z.enum(['low', 'medium', 'high', 'extra', 'max']).optional().describe('Reasoning effort level (default: high). Use lower for mechanical tasks, higher for complex/high-stakes tasks.'),
+              effort: z.preprocess(
+                (val) => val === 'extra' ? 'xhigh' : val,
+                z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional()
+              ).describe('Reasoning effort level (default: high). Valid values: low, medium, high, xhigh, max. ("extra" is accepted as an alias for "xhigh")'),
               ticket: z.string().optional().describe('Ticket/issue identifier to group tasks in the web UI (e.g. "PROJ-123")'),
               dependsOn: z.array(z.string()),
             }))

--- a/src/server/state/db.ts
+++ b/src/server/state/db.ts
@@ -33,6 +33,7 @@ export function createDb(path: string = './multiclaude.db'): Database.Database {
       max_retries INTEGER NOT NULL DEFAULT 3,
       worktree_path TEXT,
       branch TEXT,
+      head_sha TEXT,
       agent_id TEXT,
       started_at TEXT,
       duration_seconds REAL,
@@ -43,6 +44,7 @@ export function createDb(path: string = './multiclaude.db'): Database.Database {
       cost_usd REAL,
       run_id TEXT REFERENCES runs(id),
       ticket TEXT,
+      failure_reason TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
@@ -87,6 +89,8 @@ export function createDb(path: string = './multiclaude.db'): Database.Database {
   try { db.exec("ALTER TABLE tasks ADD COLUMN ticket TEXT") } catch { /* already exists */ }
   try { db.exec("ALTER TABLE runs ADD COLUMN budget_usd REAL") } catch { /* already exists */ }
   try { db.exec("ALTER TABLE tasks ADD COLUMN ticket TEXT") } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE tasks ADD COLUMN head_sha TEXT") } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE tasks ADD COLUMN failure_reason TEXT") } catch { /* already exists */ }
   return db
 }
 

--- a/src/server/state/tasks.ts
+++ b/src/server/state/tasks.ts
@@ -13,6 +13,7 @@ export interface Task {
   max_retries: number
   worktree_path: string | null
   branch: string | null
+  head_sha: string | null
   repo_path: string | null
   agent_id: string | null
   started_at: string | null
@@ -23,6 +24,7 @@ export interface Task {
   cost_usd: number | null
   run_id: string | null
   ticket: string | null
+  failure_reason: string | null
   created_at: string
   updated_at: string
 }
@@ -43,6 +45,7 @@ export interface UpdateTaskInput {
   retry_count?: number
   worktree_path?: string
   branch?: string
+  head_sha?: string
   repo_path?: string
   agent_id?: string
   started_at?: string
@@ -51,6 +54,7 @@ export interface UpdateTaskInput {
   output_tokens?: number
   total_tokens?: number
   cost_usd?: number
+  failure_reason?: string
 }
 
 export function createTask(db: Database.Database, input: CreateTaskInput): void {
@@ -81,6 +85,7 @@ export function updateTask(db: Database.Database, id: string, input: UpdateTaskI
   if (input.retry_count !== undefined) { sets.push('retry_count = @retry_count'); params.retry_count = input.retry_count }
   if (input.worktree_path !== undefined) { sets.push('worktree_path = @worktree_path'); params.worktree_path = input.worktree_path }
   if (input.branch !== undefined) { sets.push('branch = @branch'); params.branch = input.branch }
+  if (input.head_sha !== undefined) { sets.push('head_sha = @head_sha'); params.head_sha = input.head_sha }
   if (input.repo_path !== undefined) { sets.push('repo_path = @repo_path'); params.repo_path = input.repo_path }
   if (input.agent_id !== undefined) { sets.push('agent_id = @agent_id'); params.agent_id = input.agent_id }
   if (input.started_at !== undefined) { sets.push('started_at = @started_at'); params.started_at = input.started_at }
@@ -89,6 +94,7 @@ export function updateTask(db: Database.Database, id: string, input: UpdateTaskI
   if (input.output_tokens !== undefined) { sets.push('output_tokens = @output_tokens'); params.output_tokens = input.output_tokens }
   if (input.total_tokens !== undefined) { sets.push('total_tokens = @total_tokens'); params.total_tokens = input.total_tokens }
   if (input.cost_usd !== undefined) { sets.push('cost_usd = @cost_usd'); params.cost_usd = input.cost_usd }
+  if (input.failure_reason !== undefined) { sets.push('failure_reason = @failure_reason'); params.failure_reason = input.failure_reason }
 
   db.prepare(`UPDATE tasks SET ${sets.join(', ')} WHERE id = @id`).run(params as any)
 }

--- a/src/server/tools/orchestrator.ts
+++ b/src/server/tools/orchestrator.ts
@@ -8,6 +8,20 @@ import { upsertProject, listProjects } from '../state/projects.js'
 import { createRun, getRun, listRunsWithStats, RunWithStats } from '../state/runs.js'
 import { createWorktree } from '../../git/worktree.js'
 
+export const VALID_EFFORT_VALUES = ['low', 'medium', 'high', 'xhigh', 'max'] as const
+export type EffortValue = typeof VALID_EFFORT_VALUES[number]
+
+/**
+ * Normalise an effort string to a canonical EffortValue.
+ * Returns the canonical value, or null when the input is invalid.
+ * "extra" is accepted as a legacy alias for "xhigh".
+ */
+export function normalizeEffort(effort: string): EffortValue | null {
+  if (effort === 'extra') return 'xhigh'
+  if ((VALID_EFFORT_VALUES as readonly string[]).includes(effort)) return effort as EffortValue
+  return null
+}
+
 export interface EpicTask {
   id: string
   title: string
@@ -42,7 +56,17 @@ export function handlePlanDag(
     run_id = run.id
   }
   for (const t of epic.tasks) {
-    createTask(db, { id: t.id, title: t.title, description: t.description, model: t.model, effort: t.effort, run_id, ticket: t.ticket })
+    let effort: string | undefined = t.effort
+    if (effort !== undefined) {
+      const normalized = normalizeEffort(effort)
+      if (normalized === null) {
+        return {
+          error: `Invalid effort "${effort}" for task "${t.id}". Valid values: ${VALID_EFFORT_VALUES.join(', ')}. ("extra" is accepted as an alias for "xhigh")`,
+        }
+      }
+      effort = normalized
+    }
+    createTask(db, { id: t.id, title: t.title, description: t.description, model: t.model, effort, run_id, ticket: t.ticket })
   }
   for (const t of epic.tasks) {
     for (const dep of t.dependsOn) {

--- a/src/server/tools/orchestrator.ts
+++ b/src/server/tools/orchestrator.ts
@@ -241,7 +241,7 @@ export async function handleSpawnWorker(
         }
       }
       const info = await createWorktree(opts.cwd, taskId, undefined, baseBranch)
-      updateTask(db, taskId, { worktree_path: info.path, branch: info.branch, repo_path: opts.cwd })
+      updateTask(db, taskId, { worktree_path: info.path, branch: info.branch, head_sha: info.headSha, repo_path: opts.cwd })
       agentCwd = info.path
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err)

--- a/src/server/tools/orchestrator.ts
+++ b/src/server/tools/orchestrator.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import { simpleGit } from 'simple-git'
 import type Database from 'better-sqlite3'
 import { createTask, listTasks, getTask, updateTask } from '../state/tasks.js'
+import type { Task } from '../state/tasks.js'
 import { addEdge, getReadyTasks, getBlockers } from '../state/dag.js'
 import { getAgent, listAgents, registerAgent, updateAgent } from '../state/agents.js'
 import { upsertProject, listProjects } from '../state/projects.js'
@@ -123,12 +124,32 @@ function buildDagVisualization(epic: Epic): string {
   return lines.join('\n').trimEnd()
 }
 
+/** Task augmented with last_log_at so callers can distinguish working from merely registered. */
+export type TaskWithActivity = Task & {
+  /** ISO timestamp of the most recent log entry for this task, or null if no logs yet. */
+  last_log_at: string | null
+}
+
 export interface SystemStatus {
-  tasks: ReturnType<typeof listTasks>
+  tasks: TaskWithActivity[]
   agents: ReturnType<typeof listAgents>
   readyTasks: ReturnType<typeof getReadyTasks>
-  retriableTasks: ReturnType<typeof listTasks>
+  retriableTasks: TaskWithActivity[]
   runs: ReturnType<typeof listRunsWithStats>
+}
+
+/**
+ * Enriches tasks with last_log_at from the logs table.
+ * A null last_log_at means the agent has produced no log entries yet — it is
+ * "merely registered" (spawning) rather than actively working.
+ */
+export function enrichWithLastLog(db: Database.Database, tasks: ReturnType<typeof listTasks>): TaskWithActivity[] {
+  return tasks.map(task => {
+    const row = db.prepare(
+      'SELECT MAX(created_at) AS last_log FROM logs WHERE task_id = ?'
+    ).get(task.id) as { last_log: string | null }
+    return { ...task, last_log_at: row.last_log }
+  })
 }
 
 export function handleGetSystemStatus(db: Database.Database, includeDone = false): SystemStatus {
@@ -136,10 +157,10 @@ export function handleGetSystemStatus(db: Database.Database, includeDone = false
   const tasks = includeDone ? allTasks : allTasks.filter(t => t.status !== 'done' && t.status !== 'failed' && t.status !== 'cancelled')
   const retriableTasks = allTasks.filter(t => t.status === 'failed' && t.retry_count < t.max_retries)
   return {
-    tasks,
+    tasks: enrichWithLastLog(db, tasks),
     agents: listAgents(db),
     readyTasks: getReadyTasks(db),
-    retriableTasks,
+    retriableTasks: enrichWithLastLog(db, retriableTasks),
     runs: listRunsWithStats(db),
   }
 }

--- a/src/server/tools/orchestrator.ts
+++ b/src/server/tools/orchestrator.ts
@@ -3,10 +3,11 @@ import { simpleGit } from 'simple-git'
 import type Database from 'better-sqlite3'
 import { createTask, listTasks, getTask, updateTask } from '../state/tasks.js'
 import { addEdge, getReadyTasks, getBlockers } from '../state/dag.js'
-import { listAgents, registerAgent, updateAgent } from '../state/agents.js'
+import { getAgent, listAgents, registerAgent, updateAgent } from '../state/agents.js'
 import { upsertProject, listProjects } from '../state/projects.js'
 import { createRun, getRun, listRunsWithStats, RunWithStats } from '../state/runs.js'
 import { createWorktree } from '../../git/worktree.js'
+import { killTmuxWindow } from '../../spawner/tmux.js'
 
 export interface EpicTask {
   id: string
@@ -145,6 +146,12 @@ export function handleCancelTask(db: Database.Database, taskId: string): void {
   db.prepare(
     "UPDATE tasks SET status = 'cancelled', updated_at = datetime('now') WHERE id = ?"
   ).run(taskId)
+  // Reap the tmux window if one exists for this task's agent
+  const task = getTask(db, taskId)
+  if (task?.agent_id) {
+    const agent = getAgent(db, task.agent_id)
+    if (agent?.tmux_pane) killTmuxWindow(agent.tmux_pane)
+  }
 }
 
 export function handleCompleteTask(

--- a/src/server/tools/worker.ts
+++ b/src/server/tools/worker.ts
@@ -59,14 +59,14 @@ export async function handleReportDone(
         db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
           taskId, 'info', `Merged and pushed ${task.branch} to origin/${integBranch}`
         )
-        await removeWorktree(projectCwd, { path: task.worktree_path, branch: task.branch, taskId })
+        await removeWorktree(projectCwd, { path: task.worktree_path, branch: task.branch })
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err)
         db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
           taskId, 'error', `Merge conflict: ${task.branch} could not be merged into mc/integration — ${msg}`
         )
         // Clean up the worktree so retries can recreate it with the same branch name
-        await removeWorktree(projectCwd, { path: task.worktree_path, branch: task.branch, taskId })
+        await removeWorktree(projectCwd, { path: task.worktree_path, branch: task.branch })
           .catch(() => {}) // best-effort; don't mask the original merge error
         updateTask(db, taskId, { status: 'failed' })
         if (task.agent_id) updateAgent(db, task.agent_id, { status: 'done' })

--- a/src/server/tools/worker.ts
+++ b/src/server/tools/worker.ts
@@ -1,10 +1,11 @@
 import type Database from 'better-sqlite3'
 import { getTask, updateTask } from '../state/tasks.js'
 import type { Task } from '../state/tasks.js'
-import { updateAgent } from '../state/agents.js'
+import { getAgent, updateAgent } from '../state/agents.js'
 import { ensureIntegrationBranch, mergeWorktreeBranch } from '../../git/merge.js'
 import { removeWorktree } from '../../git/worktree.js'
 import { calculateCost } from '../cost.js'
+import { killTmuxWindow } from '../../spawner/tmux.js'
 
 export function handleGetMyTask(db: Database.Database, agentId: string): Task {
   const task = db.prepare(
@@ -69,7 +70,11 @@ export async function handleReportDone(
         await removeWorktree(projectCwd, { path: task.worktree_path, branch: task.branch, taskId })
           .catch(() => {}) // best-effort; don't mask the original merge error
         updateTask(db, taskId, { status: 'failed' })
-        if (task.agent_id) updateAgent(db, task.agent_id, { status: 'done' })
+        if (task.agent_id) {
+          updateAgent(db, task.agent_id, { status: 'done' })
+          const agent = getAgent(db, task.agent_id)
+          if (agent?.tmux_pane) killTmuxWindow(agent.tmux_pane)
+        }
         return
       }
     }
@@ -88,6 +93,9 @@ export async function handleReportDone(
   // Mark the agent done so the spawner watcher's exit handler doesn't flag it as failed
   if (task?.agent_id) {
     updateAgent(db, task.agent_id, { status: 'done' })
+    // Reap the tmux window now that the task is complete
+    const agent = getAgent(db, task.agent_id)
+    if (agent?.tmux_pane) killTmuxWindow(agent.tmux_pane)
   }
 }
 

--- a/src/server/tools/worker.ts
+++ b/src/server/tools/worker.ts
@@ -80,7 +80,7 @@ export async function handleReportDone(
       try {
         const runId = task.run_id ?? undefined
         await ensureIntegrationBranch(projectCwd, runId)
-        await mergeWorktreeBranch(projectCwd, task.branch, runId)
+        await mergeWorktreeBranch(projectCwd, task.branch, runId, task.worktree_path)
         const integBranch = runId ? `mc/run-${runId}` : 'mc/integration'
         db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
           taskId, 'info', `Merged and pushed ${task.branch} to origin/${integBranch}`

--- a/src/server/tools/worker.ts
+++ b/src/server/tools/worker.ts
@@ -3,7 +3,7 @@ import { simpleGit } from 'simple-git'
 import { getTask, updateTask } from '../state/tasks.js'
 import type { Task } from '../state/tasks.js'
 import { getAgent, updateAgent } from '../state/agents.js'
-import { ensureIntegrationBranch, mergeWorktreeBranch } from '../../git/merge.js'
+import { ensureIntegrationBranch, mergeWorktreeBranch, MergeConflictError } from '../../git/merge.js'
 import { removeWorktree } from '../../git/worktree.js'
 import { calculateCost } from '../cost.js'
 import { killTmuxWindow } from '../../spawner/tmux.js'
@@ -88,13 +88,14 @@ export async function handleReportDone(
         await removeWorktree(projectCwd, { path: task.worktree_path, branch: task.branch })
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err)
+        const failureReason = err instanceof MergeConflictError ? 'merge conflict' : 'merge failed'
         db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
-          taskId, 'error', `Merge conflict: ${task.branch} could not be merged into mc/integration — ${msg}`
+          taskId, 'error', `Merge failed: ${task.branch} could not be merged — ${msg}`
         )
         // Clean up the worktree so retries can recreate it with the same branch name
         await removeWorktree(projectCwd, { path: task.worktree_path, branch: task.branch })
           .catch(() => {}) // best-effort; don't mask the original merge error
-        updateTask(db, taskId, { status: 'failed' })
+        updateTask(db, taskId, { status: 'failed', failure_reason: failureReason })
         if (task.agent_id) {
           updateAgent(db, task.agent_id, { status: 'done' })
           const agent = getAgent(db, task.agent_id)

--- a/src/server/tools/worker.ts
+++ b/src/server/tools/worker.ts
@@ -1,4 +1,5 @@
 import type Database from 'better-sqlite3'
+import { simpleGit } from 'simple-git'
 import { getTask, updateTask } from '../state/tasks.js'
 import type { Task } from '../state/tasks.js'
 import { getAgent, updateAgent } from '../state/agents.js'
@@ -52,6 +53,30 @@ export async function handleReportDone(
       ? (db.prepare('SELECT p.cwd FROM projects p JOIN runs r ON r.project_id = p.id WHERE r.id = ?').get(task.run_id) as { cwd: string } | undefined)?.cwd
       : undefined)
     if (projectCwd) {
+      // Detect zero-commit branch: compare current HEAD to the SHA at worktree creation
+      if (task.head_sha) {
+        try {
+          const git = simpleGit(projectCwd)
+          const currentSha = (await git.revparse([task.branch])).trim()
+          if (currentSha === task.head_sha) {
+            const reason = 'task branch has no commits'
+            db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
+              taskId, 'error', `Empty branch: ${task.branch} has no commits since creation (head_sha=${task.head_sha})`
+            )
+            await removeWorktree(projectCwd, { path: task.worktree_path, branch: task.branch })
+              .catch(() => {})
+            updateTask(db, taskId, { status: 'failed', failure_reason: reason })
+            if (task.agent_id) {
+              updateAgent(db, task.agent_id, { status: 'done' })
+              const agent = getAgent(db, task.agent_id)
+              if (agent?.tmux_pane) killTmuxWindow(agent.tmux_pane)
+            }
+            return
+          }
+        } catch {
+          // If rev-parse fails (branch gone?), fall through to normal merge which will surface the real error
+        }
+      }
       try {
         const runId = task.run_id ?? undefined
         await ensureIntegrationBranch(projectCwd, runId)

--- a/src/spawner/index.ts
+++ b/src/spawner/index.ts
@@ -4,6 +4,7 @@ import { writeFileSync, mkdirSync, openSync, readFileSync, existsSync } from 'fs
 import { join, dirname } from 'path'
 import { tmpdir } from 'os'
 import { fileURLToPath } from 'url'
+import { readWorktreeGitDir } from '../git/worktree.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -42,12 +43,29 @@ export function buildWorkerMcpConfig(opts: { serverPort: number }): WorkerMcpCon
   }
 }
 
-export function buildWorkerEnv(agentId: string): NodeJS.ProcessEnv {
-  const env = { ...process.env, MULTICLAUDE_AGENT_ID: agentId }
-  // Remove CLAUDECODE so spawned workers don't fail with "nested session" error
-  // if multiclaude was itself started from within a Claude Code session.
-  delete (env as Record<string, string | undefined>)['CLAUDECODE']
+export interface WorktreeIsolation {
+  worktreePath: string
+  gitDir: string
+}
+
+export function buildWorkerEnv(agentId: string, isolation?: WorktreeIsolation): NodeJS.ProcessEnv {
+  const env: Record<string, string | undefined> = { ...process.env, MULTICLAUDE_AGENT_ID: agentId }
+  delete env['CLAUDECODE']
+  if (isolation) {
+    env.GIT_DIR = isolation.gitDir
+    env.GIT_WORK_TREE = isolation.worktreePath
+    env.GIT_CEILING_DIRECTORIES = dirname(isolation.worktreePath)
+  }
   return env
+}
+
+function resolveWorktreeIsolation(worktreePath: string): WorktreeIsolation | undefined {
+  try {
+    const gitDir = readWorktreeGitDir(worktreePath)
+    return { worktreePath, gitDir }
+  } catch {
+    return undefined
+  }
 }
 
 function loadWorkerPrompt(): string {
@@ -124,10 +142,11 @@ export function spawnWorker(cfg: SpawnConfig): ChildProcess {
      } }, null, 2)
   )
   const logFd = openSync(workerLogPath(cfg.agentId), 'a')
+  const isolation = resolveWorktreeIsolation(cfg.worktreePath)
   return spawn('claude', buildWorkerArgs(cfg), {
     cwd: cfg.worktreePath,
     stdio: ['ignore', logFd, logFd],
-    env: buildWorkerEnv(cfg.agentId),
+    env: buildWorkerEnv(cfg.agentId, isolation),
   })
 }
 

--- a/src/spawner/stuck-watcher.ts
+++ b/src/spawner/stuck-watcher.ts
@@ -15,6 +15,9 @@ const BUSY_PATTERNS = [
   /working\.\.\./i,
 ]
 
+/** Canonical failure reason written to logs when an agent never called get_my_task. */
+export const AGENT_NEVER_STARTED_REASON = 'agent process never started'
+
 /**
  * Returns true if the captured pane text contains a Claude Code busy footer
  * in the last ~6 non-blank lines, indicating the worker is mid-turn.
@@ -36,10 +39,16 @@ export function isPaneBusy(paneText: string): boolean {
  * - Warn (insert a log entry) if no log activity for >= stuckWarningMinutes
  * - Fail (mark task failed) if no log activity for >= stuckTimeoutMinutes
  *
+ * Also checks `spawning` agents (those that were launched but never called get_my_task):
+ * - If started_at is > firstActivitySeconds ago and still no log entries, the agent
+ *   process likely never started — mark failed immediately with AGENT_NEVER_STARTED_REASON.
+ *   This is a much tighter bound than the general staleness window and catches the
+ *   "Enter never landed in tmux" fault at spawn time rather than 10+ minutes later.
+ *
  * `stuckSince` is an in-memory Map<taskId, timestamp> tracking the first time
  * we noticed a worker was stuck — callers must pass the same Map across calls.
  *
- * `capturePane` is injectable for testing; defaults to the real tmux capture.
+ * `capturePane` and `killWindow` are injectable for testing; default to real impls.
  */
 export function checkStuckWorkers(
   db: Database.Database,
@@ -49,7 +58,44 @@ export function checkStuckWorkers(
   now: number = Date.now(),
   capturePane: (target: string, lines: number) => string = captureTmuxPane,
   killWindow: (windowId: string) => void = killTmuxWindow,
+  firstActivitySeconds: number = 60,
 ): void {
+  // --- First-activity heartbeat: spawning agents with no logs after firstActivitySeconds ---
+  // An agent that was launched but never called get_my_task (and thus never wrote a log)
+  // has almost certainly not started. Fail it quickly rather than waiting for the general
+  // staleness window (stuckTimeoutMinutes, typically 10-30 min).
+  const spawningAgents = db.prepare(
+    "SELECT id, task_id, status, tmux_pane FROM agents WHERE status = 'spawning'"
+  ).all() as RunningAgentRow[]
+
+  for (const agent of spawningAgents) {
+    if (!agent.task_id) continue
+    const task = getTask(db, agent.task_id)
+    if (!task || task.status !== 'in_progress') continue
+
+    // Skip if ANY log entry already exists — the agent is doing something
+    const logCount = (db.prepare(
+      'SELECT COUNT(*) AS cnt FROM logs WHERE task_id = ?'
+    ).get(agent.task_id) as { cnt: number }).cnt
+    if (logCount > 0) continue
+
+    const startMs = task.started_at ? new Date(task.started_at).getTime() : now
+    const elapsedSeconds = (now - startMs) / 1000
+
+    if (elapsedSeconds >= firstActivitySeconds) {
+      console.warn(
+        `[stuck-watcher] Task ${task.id} shows no activity ${firstActivitySeconds}s after spawn — agent likely never started`
+      )
+      updateTask(db, task.id, { status: 'failed' })
+      updateAgent(db, agent.id, { status: 'failed' })
+      db.prepare(
+        'INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)'
+      ).run(task.id, 'error', AGENT_NEVER_STARTED_REASON)
+      if (agent.tmux_pane) killWindow(agent.tmux_pane)
+    }
+  }
+
+  // --- Existing staleness check for running agents ---
   const runningAgents = db.prepare(
     "SELECT id, task_id, status, tmux_pane FROM agents WHERE status = 'running'"
   ).all() as RunningAgentRow[]

--- a/src/spawner/stuck-watcher.ts
+++ b/src/spawner/stuck-watcher.ts
@@ -1,7 +1,7 @@
 import type Database from 'better-sqlite3'
 import { getTask, updateTask } from '../server/state/tasks.js'
 import { updateAgent } from '../server/state/agents.js'
-import { captureTmuxPane } from './tmux.js'
+import { captureTmuxPane, killTmuxWindow } from './tmux.js'
 
 interface RunningAgentRow {
   id: string
@@ -48,6 +48,7 @@ export function checkStuckWorkers(
   stuckTimeoutMinutes: number,
   now: number = Date.now(),
   capturePane: (target: string, lines: number) => string = captureTmuxPane,
+  killWindow: (windowId: string) => void = killTmuxWindow,
 ): void {
   const runningAgents = db.prepare(
     "SELECT id, task_id, status, tmux_pane FROM agents WHERE status = 'running'"
@@ -88,6 +89,8 @@ export function checkStuckWorkers(
       db.prepare(
         'INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)'
       ).run(task.id, 'error', `timed out after ${stuckTimeoutMinutes}m with no log activity`)
+      // Reap the tmux window so it doesn't accumulate as a dead pane
+      if (agent.tmux_pane) killWindow(agent.tmux_pane)
       stuckSince.delete(task.id)
     } else if (idleMinutes >= stuckWarningMinutes) {
       if (!stuckSince.has(task.id)) {

--- a/src/spawner/tmux.ts
+++ b/src/spawner/tmux.ts
@@ -47,16 +47,32 @@ export function ensureTmuxSession(): string {
 }
 
 /**
- * Creates a tmux window named mc-<taskId> in the given session,
- * rooted at worktreePath. Returns the window target (session:window).
+ * Creates a tmux window with the given name in the given session, rooted at
+ * worktreePath. Returns the tmux window ID (@NN form), which is globally
+ * unique and stable for the lifetime of the window — use it for all
+ * subsequent targeting instead of the name-based session:name form.
  */
-export function createTmuxWindow(sessionName: string, taskId: string, worktreePath: string): string {
-  const windowName = `mc-${taskId}`
-  execSync(
-    `tmux new-window -d -t ${shellQuote(sessionName)}: -n ${shellQuote(windowName)} -c ${shellQuote(worktreePath)}`,
-    { stdio: 'pipe' }
-  )
-  return `${sessionName}:${windowName}`
+export function createTmuxWindow(sessionName: string, windowName: string, worktreePath: string): string {
+  const windowId = execSync(
+    `tmux new-window -d -P -F '#{window_id}' -t ${shellQuote(sessionName)}: -n ${shellQuote(windowName)} -c ${shellQuote(worktreePath)}`,
+    { encoding: 'utf8', stdio: 'pipe' }
+  ).trim()
+  if (!windowId) {
+    throw new Error(`Failed to get window ID for newly created tmux window '${windowName}'`)
+  }
+  return windowId
+}
+
+/**
+ * Kills a tmux window by its window ID (@NN). Silently ignores errors (window
+ * may already be dead).
+ */
+export function killTmuxWindow(windowId: string): void {
+  try {
+    execSync(`tmux kill-window -t ${shellQuote(windowId)}`, { stdio: 'pipe' })
+  } catch {
+    // Window already dead or tmux unavailable — fine
+  }
 }
 
 /**
@@ -268,14 +284,18 @@ export function spawnTmuxWorker(cfg: SpawnConfig): WorkerHandle {
   )
 
   const sessionName = ensureTmuxSession()
-  const windowTarget = createTmuxWindow(sessionName, cfg.taskId, cfg.worktreePath)
-  const panePid = getTmuxPanePid(windowTarget)
+  // Window name is unique per agent attempt — different agent IDs for retries
+  // prevent tmux from resolving -t to a stale dead window from a prior attempt.
+  const windowName = `mc-${cfg.agentId}`
+  const windowId = createTmuxWindow(sessionName, windowName, cfg.worktreePath)
+  // All targeting after this point uses the @NN window ID, not the name.
+  const panePid = getTmuxPanePid(windowId)
 
   const scriptPath = writeLaunchScript(cfg)
-  const waitSignal = `mc-${cfg.taskId}-exit`
+  const waitSignal = `mc-${cfg.agentId}-exit`
 
   // Run the script; signal when done so the monitor below detects exit
-  sendTmuxKeys(windowTarget, `bash ${shellQuote(scriptPath)}; tmux wait-for -S ${shellQuote(waitSignal)}`)
+  sendTmuxKeys(windowId, `bash ${shellQuote(scriptPath)}; tmux wait-for -S ${shellQuote(waitSignal)}`)
 
   // Monitor blocks until the signal fires (claude exits in the pane)
   const monitor = spawn('tmux', ['wait-for', waitSignal], {
@@ -285,7 +305,7 @@ export function spawnTmuxWorker(cfg: SpawnConfig): WorkerHandle {
 
   return {
     pid: panePid,
-    tmuxPane: windowTarget,
+    tmuxPane: windowId,
     onExit(cb) { monitor.on('exit', cb) },
     onError(cb) { monitor.on('error', cb) },
   }

--- a/src/spawner/tmux.ts
+++ b/src/spawner/tmux.ts
@@ -4,6 +4,8 @@ import { join } from 'path'
 
 import type { SpawnConfig } from './index.js'
 import { buildWorkerArgs, buildWorkerEnv } from './index.js'
+import { readWorktreeGitDir } from '../git/worktree.js'
+import type { WorktreeIsolation } from './index.js'
 import type { WorkerHandle } from './backend.js'
 
 /**
@@ -223,7 +225,12 @@ export function sendToPane(
  */
 export function writeLaunchScript(cfg: SpawnConfig): string {
   const args = buildWorkerArgs({ ...cfg, openTerminals: true })
-  const env = buildWorkerEnv(cfg.agentId)
+  let isolation: WorktreeIsolation | undefined
+  try {
+    const gitDir = readWorktreeGitDir(cfg.worktreePath)
+    isolation = { worktreePath: cfg.worktreePath, gitDir }
+  } catch { /* not a worktree — skip isolation */ }
+  const env = buildWorkerEnv(cfg.agentId, isolation)
 
   const lines: string[] = ['#!/usr/bin/env bash', 'set -e', '']
   for (const [key, val] of Object.entries(env)) {

--- a/src/spawner/tmux.ts
+++ b/src/spawner/tmux.ts
@@ -92,6 +92,29 @@ export function getTmuxPanePid(target: string): number | undefined {
 }
 
 /**
+ * Returns the PID of the first child process of parentPid, or undefined if
+ * the parent has no children or pgrep is unavailable.
+ *
+ * Used after tmux worker launch to detect whether the agent process (claude /
+ * its Node.js wrapper) actually started inside the pane. The pane's own shell
+ * PID is parentPid; any child it has is the running agent process.
+ */
+export function getChildProcessPid(parentPid: number): number | undefined {
+  try {
+    const raw = execSync(
+      `pgrep -P ${parentPid}`,
+      { encoding: 'utf8', stdio: 'pipe', timeout: 2000 }
+    ).trim()
+    const pids = raw.split('\n')
+      .map(s => parseInt(s.trim(), 10))
+      .filter(n => Number.isFinite(n) && n > 0)
+    return pids[0]
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * Sends a line of text to a tmux pane as keystrokes, followed by Enter.
  */
 export function sendTmuxKeys(target: string, command: string): void {

--- a/tests/git/empty-branch-detection.test.ts
+++ b/tests/git/empty-branch-detection.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createDb, closeDb } from '../../src/server/state/db.js'
+import { createTask, updateTask, getTask } from '../../src/server/state/tasks.js'
+import { registerAgent } from '../../src/server/state/agents.js'
+import { handleReportDone } from '../../src/server/tools/worker.js'
+import { createWorktree, removeWorktree } from '../../src/git/worktree.js'
+import { ensureIntegrationBranch } from '../../src/git/merge.js'
+import { execSync } from 'child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type Database from 'better-sqlite3'
+
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'mc-empty-branch-test-'))
+  execSync('git init', { cwd: dir })
+  execSync('git config user.email "test@test.com"', { cwd: dir })
+  execSync('git config user.name "Test"', { cwd: dir })
+  execSync('echo "init" > README.md && git add . && git commit -m "init"', { cwd: dir })
+  return dir
+}
+
+describe('empty branch detection', () => {
+  let db: Database.Database
+  let repoPath: string
+
+  beforeEach(() => {
+    db = createDb(':memory:')
+    repoPath = makeRepo()
+  })
+
+  afterEach(() => {
+    closeDb(db)
+    rmSync(repoPath, { recursive: true, force: true })
+  })
+
+  it('marks task failed when task branch has no commits', async () => {
+    const info = await createWorktree(repoPath, 'task-empty', 'feat: empty task')
+
+    createTask(db, { id: 'task-empty', title: 'Empty task' })
+    updateTask(db, 'task-empty', {
+      status: 'in_progress',
+      worktree_path: info.path,
+      branch: info.branch,
+      head_sha: info.headSha,
+      repo_path: repoPath,
+      agent_id: 'w-empty',
+    })
+    registerAgent(db, { id: 'w-empty', task_id: 'task-empty' })
+
+    // Do NOT commit anything — zero-commit branch
+
+    await handleReportDone(db, 'task-empty', 'task complete')
+
+    const task = getTask(db, 'task-empty')
+    expect(task?.status).toBe('failed')
+    expect(task?.failure_reason).toBe('task branch has no commits')
+
+    // Verify the failure is logged
+    const log = db.prepare("SELECT * FROM logs WHERE task_id = 'task-empty' AND level = 'error'").get() as { message: string } | undefined
+    expect(log?.message).toContain('no commits')
+  })
+
+  it('marks task done and merges when task branch has commits', async () => {
+    await ensureIntegrationBranch(repoPath, 'run-123')
+    const info = await createWorktree(repoPath, 'task-with-commits', 'feat: real work')
+
+    createTask(db, { id: 'task-with-commits', title: 'Real work', run_id: undefined })
+    updateTask(db, 'task-with-commits', {
+      status: 'in_progress',
+      worktree_path: info.path,
+      branch: info.branch,
+      head_sha: info.headSha,
+      repo_path: repoPath,
+      agent_id: 'w-commits',
+    })
+    registerAgent(db, { id: 'w-commits', task_id: 'task-with-commits' })
+
+    // Make a real commit in the worktree
+    writeFileSync(join(info.path, 'feature.ts'), 'export const x = 1')
+    execSync('git add . && git commit -m "add feature"', { cwd: info.path })
+
+    await handleReportDone(db, 'task-with-commits', 'feature implemented')
+
+    const task = getTask(db, 'task-with-commits')
+    expect(task?.status).toBe('done')
+    expect(task?.failure_reason).toBeNull()
+
+    // Verify the success log is written
+    const log = db.prepare("SELECT * FROM logs WHERE task_id = 'task-with-commits' AND level = 'info' AND message LIKE 'DONE:%'").get() as { message: string } | undefined
+    expect(log?.message).toContain('feature implemented')
+  })
+
+  it('proceeds normally when head_sha is not stored (legacy task without head_sha)', async () => {
+    await ensureIntegrationBranch(repoPath)
+    const info = await createWorktree(repoPath, 'task-legacy', 'feat: legacy task')
+
+    createTask(db, { id: 'task-legacy', title: 'Legacy task' })
+    updateTask(db, 'task-legacy', {
+      status: 'in_progress',
+      worktree_path: info.path,
+      branch: info.branch,
+      // intentionally omit head_sha — simulates old task records without the column
+      repo_path: repoPath,
+      agent_id: 'w-legacy',
+    })
+    registerAgent(db, { id: 'w-legacy', task_id: 'task-legacy' })
+
+    writeFileSync(join(info.path, 'legacy.ts'), 'export const legacy = true')
+    execSync('git add . && git commit -m "legacy commit"', { cwd: info.path })
+
+    await handleReportDone(db, 'task-legacy', 'legacy done')
+
+    const task = getTask(db, 'task-legacy')
+    expect(task?.status).toBe('done')
+  })
+
+  it('failure_reason is stored on the task record and visible via getTask', async () => {
+    const info = await createWorktree(repoPath, 'task-reason', 'feat: reason check')
+
+    createTask(db, { id: 'task-reason', title: 'Reason check' })
+    updateTask(db, 'task-reason', {
+      status: 'in_progress',
+      worktree_path: info.path,
+      branch: info.branch,
+      head_sha: info.headSha,
+      repo_path: repoPath,
+      agent_id: 'w-reason',
+    })
+    registerAgent(db, { id: 'w-reason', task_id: 'task-reason' })
+
+    await handleReportDone(db, 'task-reason', 'done')
+
+    const task = getTask(db, 'task-reason')
+    expect(task?.failure_reason).toBe('task branch has no commits')
+    // Confirms the field is persisted and readable, not just set in-memory
+  })
+})

--- a/tests/git/merge-conflict-reduction.test.ts
+++ b/tests/git/merge-conflict-reduction.test.ts
@@ -1,0 +1,419 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { ensureIntegrationBranch, mergeWorktreeBranch, MergeConflictError, isAutoResolvable } from '../../src/git/merge.js'
+import { createWorktree, removeWorktree } from '../../src/git/worktree.js'
+import { execSync } from 'child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'mc-conflict-reduction-'))
+  execSync('git init', { cwd: dir })
+  execSync('git config user.email "test@test.com"', { cwd: dir })
+  execSync('git config user.name "Test"', { cwd: dir })
+  execSync('echo "init" > README.md && git add . && git commit -m "init"', { cwd: dir })
+  return dir
+}
+
+describe('isAutoResolvable', () => {
+  it('identifies standard lockfiles', () => {
+    expect(isAutoResolvable('package-lock.json')).toBe(true)
+    expect(isAutoResolvable('yarn.lock')).toBe(true)
+    expect(isAutoResolvable('pnpm-lock.yaml')).toBe(true)
+    expect(isAutoResolvable('Gemfile.lock')).toBe(true)
+    expect(isAutoResolvable('Cargo.lock')).toBe(true)
+    expect(isAutoResolvable('poetry.lock')).toBe(true)
+    expect(isAutoResolvable('composer.lock')).toBe(true)
+    expect(isAutoResolvable('Pipfile.lock')).toBe(true)
+    expect(isAutoResolvable('go.sum')).toBe(true)
+    expect(isAutoResolvable('go.mod')).toBe(true)
+    expect(isAutoResolvable('bun.lockb')).toBe(true)
+  })
+
+  it('identifies lockfiles by .lock extension', () => {
+    expect(isAutoResolvable('some-custom.lock')).toBe(true)
+    expect(isAutoResolvable('flake.lock')).toBe(true)
+  })
+
+  it('handles nested paths', () => {
+    expect(isAutoResolvable('packages/web/package-lock.json')).toBe(true)
+    expect(isAutoResolvable('services/api/yarn.lock')).toBe(true)
+  })
+
+  it('rejects source code files', () => {
+    expect(isAutoResolvable('src/index.ts')).toBe(false)
+    expect(isAutoResolvable('package.json')).toBe(true) // package.json IS auto-resolvable
+    expect(isAutoResolvable('README.md')).toBe(false)
+    expect(isAutoResolvable('src/utils.js')).toBe(false)
+    expect(isAutoResolvable('test/app.test.ts')).toBe(false)
+  })
+})
+
+describe('update-before-merge', () => {
+  let repoPath: string
+
+  beforeEach(() => {
+    repoPath = makeRepo()
+  })
+
+  afterEach(() => {
+    rmSync(repoPath, { recursive: true, force: true })
+  })
+
+  it('updates task branch with integration changes before assembly merge', async () => {
+    const runId = 'update-test'
+    await ensureIntegrationBranch(repoPath, runId)
+    const integBranch = `mc/run-${runId}`
+
+    // First task merges into integration
+    const info1 = await createWorktree(repoPath, 'task-up-1')
+    writeFileSync(join(info1.path, 'first.ts'), 'export const first = 1')
+    execSync('git add . && git commit -m "add first"', { cwd: info1.path })
+    await mergeWorktreeBranch(repoPath, info1.branch, runId)
+    await removeWorktree(repoPath, info1)
+
+    // Second task: branched from main (stale — doesn't have first.ts)
+    const info2 = await createWorktree(repoPath, 'task-up-2')
+    writeFileSync(join(info2.path, 'second.ts'), 'export const second = 2')
+    execSync('git add . && git commit -m "add second"', { cwd: info2.path })
+
+    await mergeWorktreeBranch(repoPath, info2.branch, runId, info2.path)
+
+    // After the update step, task branch should contain first.ts
+    const taskHasFirst = execSync(`git show ${info2.branch}:first.ts`, { cwd: repoPath }).toString()
+    expect(taskHasFirst).toContain('export const first = 1')
+
+    // Integration branch should have both files
+    const intFirst = execSync(`git show ${integBranch}:first.ts`, { cwd: repoPath }).toString()
+    const intSecond = execSync(`git show ${integBranch}:second.ts`, { cwd: repoPath }).toString()
+    expect(intFirst).toContain('export const first = 1')
+    expect(intSecond).toContain('export const second = 2')
+
+    await removeWorktree(repoPath, info2)
+  })
+
+  it('skips update when integration has not diverged from task branch', async () => {
+    const runId = 'no-update'
+    await ensureIntegrationBranch(repoPath, runId)
+    const integBranch = `mc/run-${runId}`
+
+    // Task branched from same point as integration — no update needed
+    const info = await createWorktree(repoPath, 'task-same-base')
+    writeFileSync(join(info.path, 'feature.ts'), 'export const x = 1')
+    execSync('git add . && git commit -m "add feature"', { cwd: info.path })
+
+    // Should merge cleanly without needing an update
+    await expect(mergeWorktreeBranch(repoPath, info.branch, runId)).resolves.not.toThrow()
+
+    const content = execSync(`git show ${integBranch}:feature.ts`, { cwd: repoPath }).toString()
+    expect(content).toContain('export const x = 1')
+
+    await removeWorktree(repoPath, info)
+  })
+
+  it('handles three sequential merges with stale task branches', async () => {
+    const runId = 'three-tasks'
+    await ensureIntegrationBranch(repoPath, runId)
+    const integBranch = `mc/run-${runId}`
+
+    // All three tasks branch from main simultaneously (before any merges)
+    const info1 = await createWorktree(repoPath, 'task-3a')
+    writeFileSync(join(info1.path, 'a.ts'), 'export const a = 1')
+    execSync('git add . && git commit -m "add a"', { cwd: info1.path })
+
+    const info2 = await createWorktree(repoPath, 'task-3b')
+    writeFileSync(join(info2.path, 'b.ts'), 'export const b = 2')
+    execSync('git add . && git commit -m "add b"', { cwd: info2.path })
+
+    const info3 = await createWorktree(repoPath, 'task-3c')
+    writeFileSync(join(info3.path, 'c.ts'), 'export const c = 3')
+    execSync('git add . && git commit -m "add c"', { cwd: info3.path })
+
+    // Merge sequentially — each subsequent merge faces a stale task branch
+    await mergeWorktreeBranch(repoPath, info1.branch, runId, info1.path)
+    await mergeWorktreeBranch(repoPath, info2.branch, runId, info2.path)
+    await mergeWorktreeBranch(repoPath, info3.branch, runId, info3.path)
+
+    // All files should be in integration
+    expect(execSync(`git show ${integBranch}:a.ts`, { cwd: repoPath }).toString()).toContain('export const a = 1')
+    expect(execSync(`git show ${integBranch}:b.ts`, { cwd: repoPath }).toString()).toContain('export const b = 2')
+    expect(execSync(`git show ${integBranch}:c.ts`, { cwd: repoPath }).toString()).toContain('export const c = 3')
+
+    // Task branches should be updated with prior tasks' changes
+    expect(execSync(`git show ${info2.branch}:a.ts`, { cwd: repoPath }).toString()).toContain('export const a = 1')
+    expect(execSync(`git show ${info3.branch}:a.ts`, { cwd: repoPath }).toString()).toContain('export const a = 1')
+    expect(execSync(`git show ${info3.branch}:b.ts`, { cwd: repoPath }).toString()).toContain('export const b = 2')
+
+    await removeWorktree(repoPath, info1)
+    await removeWorktree(repoPath, info2)
+    await removeWorktree(repoPath, info3)
+  })
+})
+
+describe('extended auto-resolution', () => {
+  let repoPath: string
+
+  beforeEach(() => {
+    repoPath = makeRepo()
+  })
+
+  afterEach(() => {
+    rmSync(repoPath, { recursive: true, force: true })
+  })
+
+  it('auto-resolves yarn.lock add/add conflict', async () => {
+    const runId = 'yarn-lock'
+    await ensureIntegrationBranch(repoPath, runId)
+    const integBranch = `mc/run-${runId}`
+
+    // Add yarn.lock on integration branch
+    const origBranch = execSync('git branch --show-current', { cwd: repoPath }).toString().trim()
+    execSync(`git checkout ${integBranch}`, { cwd: repoPath })
+    writeFileSync(join(repoPath, 'yarn.lock'), '# yarn lockfile v1\nresolved "integ"')
+    execSync('git add . && git commit -m "add yarn.lock on integ"', { cwd: repoPath })
+    execSync(`git checkout ${origBranch}`, { cwd: repoPath })
+
+    // Create worktree with different yarn.lock
+    const info = await createWorktree(repoPath, 'task-yarn')
+    writeFileSync(join(info.path, 'yarn.lock'), '# yarn lockfile v1\nresolved "worker"')
+    writeFileSync(join(info.path, 'feature.ts'), 'export const f = 1')
+    execSync('git add . && git commit -m "add yarn.lock + feature"', { cwd: info.path })
+
+    await expect(mergeWorktreeBranch(repoPath, info.branch, runId)).resolves.not.toThrow()
+
+    // Feature file should be in integration
+    const feature = execSync(`git show ${integBranch}:feature.ts`, { cwd: repoPath }).toString()
+    expect(feature).toContain('export const f = 1')
+
+    await removeWorktree(repoPath, info)
+  })
+
+  it('auto-resolves pnpm-lock.yaml add/add conflict', async () => {
+    const runId = 'pnpm-lock'
+    await ensureIntegrationBranch(repoPath, runId)
+    const integBranch = `mc/run-${runId}`
+
+    const origBranch = execSync('git branch --show-current', { cwd: repoPath }).toString().trim()
+    execSync(`git checkout ${integBranch}`, { cwd: repoPath })
+    writeFileSync(join(repoPath, 'pnpm-lock.yaml'), 'lockfileVersion: 5.4\nintegration: true')
+    execSync('git add . && git commit -m "add pnpm-lock on integ"', { cwd: repoPath })
+    execSync(`git checkout ${origBranch}`, { cwd: repoPath })
+
+    const info = await createWorktree(repoPath, 'task-pnpm')
+    writeFileSync(join(info.path, 'pnpm-lock.yaml'), 'lockfileVersion: 5.4\nworker: true')
+    execSync('git add . && git commit -m "add pnpm-lock"', { cwd: info.path })
+
+    await expect(mergeWorktreeBranch(repoPath, info.branch, runId)).resolves.not.toThrow()
+
+    await removeWorktree(repoPath, info)
+  })
+
+  it('auto-resolves Cargo.lock conflict', async () => {
+    const runId = 'cargo-lock'
+    await ensureIntegrationBranch(repoPath, runId)
+    const integBranch = `mc/run-${runId}`
+
+    const origBranch = execSync('git branch --show-current', { cwd: repoPath }).toString().trim()
+    execSync(`git checkout ${integBranch}`, { cwd: repoPath })
+    writeFileSync(join(repoPath, 'Cargo.lock'), '[[package]]\nname = "integ"')
+    execSync('git add . && git commit -m "add Cargo.lock on integ"', { cwd: repoPath })
+    execSync(`git checkout ${origBranch}`, { cwd: repoPath })
+
+    const info = await createWorktree(repoPath, 'task-cargo')
+    writeFileSync(join(info.path, 'Cargo.lock'), '[[package]]\nname = "worker"')
+    execSync('git add . && git commit -m "add Cargo.lock"', { cwd: info.path })
+
+    await expect(mergeWorktreeBranch(repoPath, info.branch, runId)).resolves.not.toThrow()
+
+    await removeWorktree(repoPath, info)
+  })
+
+  it('auto-resolves lockfile conflict alongside source code (no conflict in source)', async () => {
+    const runId = 'mixed-lock'
+    await ensureIntegrationBranch(repoPath, runId)
+    const integBranch = `mc/run-${runId}`
+
+    const origBranch = execSync('git branch --show-current', { cwd: repoPath }).toString().trim()
+    execSync(`git checkout ${integBranch}`, { cwd: repoPath })
+    writeFileSync(join(repoPath, 'package-lock.json'), '{"integ": true}')
+    writeFileSync(join(repoPath, 'integ-only.ts'), 'export const integ = 1')
+    execSync('git add . && git commit -m "integ changes"', { cwd: repoPath })
+    execSync(`git checkout ${origBranch}`, { cwd: repoPath })
+
+    const info = await createWorktree(repoPath, 'task-mixed')
+    writeFileSync(join(info.path, 'package-lock.json'), '{"worker": true}')
+    writeFileSync(join(info.path, 'worker-only.ts'), 'export const worker = 1')
+    execSync('git add . && git commit -m "worker changes"', { cwd: info.path })
+
+    await expect(mergeWorktreeBranch(repoPath, info.branch, runId)).resolves.not.toThrow()
+
+    // Both source files should be present
+    expect(execSync(`git show ${integBranch}:integ-only.ts`, { cwd: repoPath }).toString()).toContain('export const integ = 1')
+    expect(execSync(`git show ${integBranch}:worker-only.ts`, { cwd: repoPath }).toString()).toContain('export const worker = 1')
+
+    await removeWorktree(repoPath, info)
+  })
+})
+
+describe('unresolvable conflict failure', () => {
+  let repoPath: string
+
+  beforeEach(() => {
+    repoPath = makeRepo()
+  })
+
+  afterEach(() => {
+    rmSync(repoPath, { recursive: true, force: true })
+  })
+
+  it('throws MergeConflictError with file paths for source code conflicts', async () => {
+    const runId = 'src-conflict'
+    await ensureIntegrationBranch(repoPath, runId)
+    const integBranch = `mc/run-${runId}`
+
+    const origBranch = execSync('git branch --show-current', { cwd: repoPath }).toString().trim()
+    execSync(`git checkout ${integBranch}`, { cwd: repoPath })
+    writeFileSync(join(repoPath, 'conflict.ts'), 'export const value = "integration"')
+    execSync('git add . && git commit -m "integ side"', { cwd: repoPath })
+    execSync(`git checkout ${origBranch}`, { cwd: repoPath })
+
+    const info = await createWorktree(repoPath, 'task-src-conflict')
+    writeFileSync(join(info.path, 'conflict.ts'), 'export const value = "worker"')
+    execSync('git add . && git commit -m "worker side"', { cwd: info.path })
+
+    try {
+      await mergeWorktreeBranch(repoPath, info.branch, runId)
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(MergeConflictError)
+      const conflict = err as MergeConflictError
+      expect(conflict.conflictedFiles).toContain('conflict.ts')
+      expect(conflict.message).toContain('conflict.ts')
+    }
+
+    await removeWorktree(repoPath, info)
+  })
+
+  it('auto-resolves lockfile but fails on source conflict in the same merge', async () => {
+    const runId = 'partial-resolve'
+    await ensureIntegrationBranch(repoPath, runId)
+    const integBranch = `mc/run-${runId}`
+
+    const origBranch = execSync('git branch --show-current', { cwd: repoPath }).toString().trim()
+    execSync(`git checkout ${integBranch}`, { cwd: repoPath })
+    writeFileSync(join(repoPath, 'package-lock.json'), '{"integ": true}')
+    writeFileSync(join(repoPath, 'conflict.ts'), 'export const x = "integ"')
+    execSync('git add . && git commit -m "integ side"', { cwd: repoPath })
+    execSync(`git checkout ${origBranch}`, { cwd: repoPath })
+
+    const info = await createWorktree(repoPath, 'task-partial')
+    writeFileSync(join(info.path, 'package-lock.json'), '{"worker": true}')
+    writeFileSync(join(info.path, 'conflict.ts'), 'export const x = "worker"')
+    execSync('git add . && git commit -m "worker side"', { cwd: info.path })
+
+    try {
+      await mergeWorktreeBranch(repoPath, info.branch, runId)
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(MergeConflictError)
+      const conflict = err as MergeConflictError
+      // Only source code conflict should be reported, not the lockfile
+      expect(conflict.conflictedFiles).toContain('conflict.ts')
+      expect(conflict.conflictedFiles).not.toContain('package-lock.json')
+    }
+
+    await removeWorktree(repoPath, info)
+  })
+
+  it('leaves integration branch unchanged when conflict cannot be resolved', async () => {
+    const runId = 'clean-after-fail'
+    await ensureIntegrationBranch(repoPath, runId)
+    const integBranch = `mc/run-${runId}`
+
+    const origBranch = execSync('git branch --show-current', { cwd: repoPath }).toString().trim()
+    execSync(`git checkout ${integBranch}`, { cwd: repoPath })
+    writeFileSync(join(repoPath, 'x.ts'), 'integ')
+    execSync('git add . && git commit -m "integ"', { cwd: repoPath })
+    const headBefore = execSync('git rev-parse HEAD', { cwd: repoPath }).toString().trim()
+    execSync(`git checkout ${origBranch}`, { cwd: repoPath })
+
+    const info = await createWorktree(repoPath, 'task-clean-fail')
+    writeFileSync(join(info.path, 'x.ts'), 'worker')
+    execSync('git add . && git commit -m "worker"', { cwd: info.path })
+
+    await expect(mergeWorktreeBranch(repoPath, info.branch, runId)).rejects.toThrow(MergeConflictError)
+
+    const headAfter = execSync(`git rev-parse ${integBranch}`, { cwd: repoPath }).toString().trim()
+    expect(headAfter).toBe(headBefore)
+
+    await removeWorktree(repoPath, info)
+  })
+})
+
+describe('serialization guarantee', () => {
+  let repoPath: string
+
+  beforeEach(() => {
+    repoPath = makeRepo()
+  })
+
+  afterEach(() => {
+    rmSync(repoPath, { recursive: true, force: true })
+  })
+
+  it('concurrent merges with update-before-merge both succeed', async () => {
+    const runId = 'concurrent-update'
+    await ensureIntegrationBranch(repoPath, runId)
+    const integBranch = `mc/run-${runId}`
+
+    const info1 = await createWorktree(repoPath, 'task-cu-1')
+    writeFileSync(join(info1.path, 'a.ts'), 'export const a = 1')
+    execSync('git add . && git commit -m "add a"', { cwd: info1.path })
+
+    const info2 = await createWorktree(repoPath, 'task-cu-2')
+    writeFileSync(join(info2.path, 'b.ts'), 'export const b = 2')
+    execSync('git add . && git commit -m "add b"', { cwd: info2.path })
+
+    // Fire both merges concurrently — serialization ensures correctness
+    await Promise.all([
+      mergeWorktreeBranch(repoPath, info1.branch, runId, info1.path),
+      mergeWorktreeBranch(repoPath, info2.branch, runId, info2.path),
+    ])
+
+    // Both files should be present
+    expect(execSync(`git show ${integBranch}:a.ts`, { cwd: repoPath }).toString()).toContain('export const a = 1')
+    expect(execSync(`git show ${integBranch}:b.ts`, { cwd: repoPath }).toString()).toContain('export const b = 2')
+
+    await removeWorktree(repoPath, info1)
+    await removeWorktree(repoPath, info2)
+  })
+
+  it('concurrent merges with lockfile conflicts both succeed via auto-resolution', async () => {
+    const runId = 'concurrent-lock'
+    await ensureIntegrationBranch(repoPath, runId)
+    const integBranch = `mc/run-${runId}`
+
+    const info1 = await createWorktree(repoPath, 'task-cl-1')
+    writeFileSync(join(info1.path, 'package-lock.json'), '{"task1": true}')
+    writeFileSync(join(info1.path, 'feat1.ts'), 'export const f1 = 1')
+    execSync('git add . && git commit -m "task1 changes"', { cwd: info1.path })
+
+    const info2 = await createWorktree(repoPath, 'task-cl-2')
+    writeFileSync(join(info2.path, 'package-lock.json'), '{"task2": true}')
+    writeFileSync(join(info2.path, 'feat2.ts'), 'export const f2 = 2')
+    execSync('git add . && git commit -m "task2 changes"', { cwd: info2.path })
+
+    // Both tasks add package-lock.json — auto-resolution should handle it
+    await Promise.all([
+      mergeWorktreeBranch(repoPath, info1.branch, runId, info1.path),
+      mergeWorktreeBranch(repoPath, info2.branch, runId, info2.path),
+    ])
+
+    // Both feature files should be present
+    expect(execSync(`git show ${integBranch}:feat1.ts`, { cwd: repoPath }).toString()).toContain('export const f1 = 1')
+    expect(execSync(`git show ${integBranch}:feat2.ts`, { cwd: repoPath }).toString()).toContain('export const f2 = 2')
+
+    await removeWorktree(repoPath, info1)
+    await removeWorktree(repoPath, info2)
+  })
+})

--- a/tests/git/merge-verification.test.ts
+++ b/tests/git/merge-verification.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createDb, closeDb } from '../../src/server/state/db.js'
+import { createTask, updateTask, getTask } from '../../src/server/state/tasks.js'
+import { registerAgent } from '../../src/server/state/agents.js'
+import { handleReportDone } from '../../src/server/tools/worker.js'
+import { createWorktree, removeWorktree } from '../../src/git/worktree.js'
+import { ensureIntegrationBranch, mergeWorktreeBranch, MergeConflictError } from '../../src/git/merge.js'
+import { execSync } from 'child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type Database from 'better-sqlite3'
+
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'mc-merge-verify-test-'))
+  execSync('git init', { cwd: dir })
+  execSync('git config user.email "test@test.com"', { cwd: dir })
+  execSync('git config user.name "Test"', { cwd: dir })
+  execSync('echo "init" > README.md && git add . && git commit -m "init"', { cwd: dir })
+  return dir
+}
+
+describe('merge verification', () => {
+  let repoPath: string
+
+  beforeEach(() => {
+    repoPath = makeRepo()
+  })
+
+  afterEach(() => {
+    rmSync(repoPath, { recursive: true, force: true })
+  })
+
+  it('ancestor check passes after successful merge', async () => {
+    const runId = 'ancestor-pass'
+    await ensureIntegrationBranch(repoPath, runId)
+    const info = await createWorktree(repoPath, 'task-ok', 'feat: ok')
+
+    writeFileSync(join(info.path, 'feature.ts'), 'export const x = 1')
+    execSync('git add . && git commit -m "add feature"', { cwd: info.path })
+
+    await mergeWorktreeBranch(repoPath, info.branch, runId)
+
+    // Verify the task branch is an ancestor of the integration branch
+    const result = execSync(
+      `git merge-base --is-ancestor ${info.branch} mc/run-${runId} && echo yes || echo no`,
+      { cwd: repoPath }
+    ).toString().trim()
+    expect(result).toBe('yes')
+
+    await removeWorktree(repoPath, info)
+  })
+
+  it('ancestor check detects unmerged branches', async () => {
+    const runId = 'ancestor-fail'
+    await ensureIntegrationBranch(repoPath, runId)
+    const info = await createWorktree(repoPath, 'task-unmerged', 'feat: unmerged')
+
+    writeFileSync(join(info.path, 'unmerged.ts'), 'export const y = 2')
+    execSync('git add . && git commit -m "unmerged commit"', { cwd: info.path })
+
+    // Do NOT merge — the task branch should NOT be an ancestor of the integration branch
+    const exitCode = execSync(
+      `git merge-base --is-ancestor ${info.branch} mc/run-${runId} 2>/dev/null; echo $?`,
+      { cwd: repoPath }
+    ).toString().trim()
+    expect(exitCode).toBe('1')
+
+    await removeWorktree(repoPath, info)
+  })
+
+  it('conflicted merge throws MergeConflictError', async () => {
+    const runId = 'conflict-test'
+    await ensureIntegrationBranch(repoPath, runId)
+    const integBranch = `mc/run-${runId}`
+
+    // Diverge the integration branch with a conflicting file
+    const origBranch = execSync('git branch --show-current', { cwd: repoPath }).toString().trim()
+    execSync(`git checkout ${integBranch}`, { cwd: repoPath })
+    writeFileSync(join(repoPath, 'conflict.ts'), 'export const value = "integration"')
+    execSync('git add . && git commit -m "integ side"', { cwd: repoPath })
+    execSync(`git checkout ${origBranch}`, { cwd: repoPath })
+
+    // Create worktree with a conflicting change
+    const info = await createWorktree(repoPath, 'task-conflict', 'feat: conflict')
+    writeFileSync(join(info.path, 'conflict.ts'), 'export const value = "worker"')
+    execSync('git add . && git commit -m "worker side"', { cwd: info.path })
+
+    await expect(mergeWorktreeBranch(repoPath, info.branch, runId))
+      .rejects.toThrow(MergeConflictError)
+
+    await removeWorktree(repoPath, info)
+  })
+
+  it('conflicted merge leaves the integration branch unchanged', async () => {
+    const runId = 'clean-state'
+    await ensureIntegrationBranch(repoPath, runId)
+    const integBranch = `mc/run-${runId}`
+
+    // Record integration branch HEAD before the failed merge
+    const origBranch = execSync('git branch --show-current', { cwd: repoPath }).toString().trim()
+    execSync(`git checkout ${integBranch}`, { cwd: repoPath })
+    writeFileSync(join(repoPath, 'conflict.ts'), 'export const v = "a"')
+    execSync('git add . && git commit -m "integ change"', { cwd: repoPath })
+    const headBefore = execSync('git rev-parse HEAD', { cwd: repoPath }).toString().trim()
+    execSync(`git checkout ${origBranch}`, { cwd: repoPath })
+
+    const info = await createWorktree(repoPath, 'task-clean', 'feat: clean')
+    writeFileSync(join(info.path, 'conflict.ts'), 'export const v = "b"')
+    execSync('git add . && git commit -m "worker change"', { cwd: info.path })
+
+    await expect(mergeWorktreeBranch(repoPath, info.branch, runId))
+      .rejects.toThrow(MergeConflictError)
+
+    // Integration branch HEAD should be unchanged
+    const headAfter = execSync(`git rev-parse ${integBranch}`, { cwd: repoPath }).toString().trim()
+    expect(headAfter).toBe(headBefore)
+
+    await removeWorktree(repoPath, info)
+  })
+
+  it('MergeConflictError exposes conflicted file names', async () => {
+    const runId = 'conflict-files'
+    await ensureIntegrationBranch(repoPath, runId)
+    const integBranch = `mc/run-${runId}`
+
+    const origBranch = execSync('git branch --show-current', { cwd: repoPath }).toString().trim()
+    execSync(`git checkout ${integBranch}`, { cwd: repoPath })
+    writeFileSync(join(repoPath, 'a.ts'), 'integ')
+    writeFileSync(join(repoPath, 'b.ts'), 'integ')
+    execSync('git add . && git commit -m "integ files"', { cwd: repoPath })
+    execSync(`git checkout ${origBranch}`, { cwd: repoPath })
+
+    const info = await createWorktree(repoPath, 'task-files', 'feat: files')
+    writeFileSync(join(info.path, 'a.ts'), 'worker')
+    writeFileSync(join(info.path, 'b.ts'), 'worker')
+    execSync('git add . && git commit -m "worker files"', { cwd: info.path })
+
+    try {
+      await mergeWorktreeBranch(repoPath, info.branch, runId)
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(MergeConflictError)
+      const conflict = err as MergeConflictError
+      expect(conflict.conflictedFiles).toContain('a.ts')
+      expect(conflict.conflictedFiles).toContain('b.ts')
+      expect(conflict.taskBranch).toBe(info.branch)
+      expect(conflict.integBranch).toBe(integBranch)
+    }
+
+    await removeWorktree(repoPath, info)
+  })
+})
+
+describe('merge verification in handleReportDone', () => {
+  let db: Database.Database
+  let repoPath: string
+
+  beforeEach(() => {
+    db = createDb(':memory:')
+    repoPath = makeRepo()
+  })
+
+  afterEach(() => {
+    closeDb(db)
+    rmSync(repoPath, { recursive: true, force: true })
+  })
+
+  it('marks task done when merge succeeds and ancestor check passes', async () => {
+    await ensureIntegrationBranch(repoPath)
+    const info = await createWorktree(repoPath, 'task-done', 'feat: done')
+
+    createTask(db, { id: 'task-done', title: 'Done task' })
+    updateTask(db, 'task-done', {
+      status: 'in_progress',
+      worktree_path: info.path,
+      branch: info.branch,
+      head_sha: info.headSha,
+      repo_path: repoPath,
+      agent_id: 'w-done',
+    })
+    registerAgent(db, { id: 'w-done', task_id: 'task-done' })
+
+    writeFileSync(join(info.path, 'feature.ts'), 'export const x = 1')
+    execSync('git add . && git commit -m "add feature"', { cwd: info.path })
+
+    await handleReportDone(db, 'task-done', 'feature complete')
+
+    const task = getTask(db, 'task-done')
+    expect(task?.status).toBe('done')
+    expect(task?.failure_reason).toBeNull()
+  })
+
+  it('marks task failed with "merge conflict" reason on conflict', async () => {
+    await ensureIntegrationBranch(repoPath)
+    const integBranch = 'mc/integration'
+
+    // Diverge the integration branch
+    const origBranch = execSync('git branch --show-current', { cwd: repoPath }).toString().trim()
+    execSync(`git checkout ${integBranch}`, { cwd: repoPath })
+    writeFileSync(join(repoPath, 'conflict.ts'), 'export const v = "integ"')
+    execSync('git add . && git commit -m "integ side"', { cwd: repoPath })
+    execSync(`git checkout ${origBranch}`, { cwd: repoPath })
+
+    const info = await createWorktree(repoPath, 'task-conflict', 'feat: conflict')
+
+    createTask(db, { id: 'task-conflict', title: 'Conflict task' })
+    updateTask(db, 'task-conflict', {
+      status: 'in_progress',
+      worktree_path: info.path,
+      branch: info.branch,
+      head_sha: info.headSha,
+      repo_path: repoPath,
+      agent_id: 'w-conflict',
+    })
+    registerAgent(db, { id: 'w-conflict', task_id: 'task-conflict' })
+
+    writeFileSync(join(info.path, 'conflict.ts'), 'export const v = "worker"')
+    execSync('git add . && git commit -m "worker side"', { cwd: info.path })
+
+    await handleReportDone(db, 'task-conflict', 'task done')
+
+    const task = getTask(db, 'task-conflict')
+    expect(task?.status).toBe('failed')
+    expect(task?.failure_reason).toBe('merge conflict')
+
+    const log = db.prepare(
+      "SELECT * FROM logs WHERE task_id = 'task-conflict' AND level = 'error'"
+    ).get() as { message: string } | undefined
+    expect(log?.message).toContain('Merge failed')
+    expect(log?.message).toContain('conflict')
+  })
+
+  it('failure_reason distinguishes "merge conflict" from "task branch has no commits"', async () => {
+    // Set up an empty-branch scenario
+    const info = await createWorktree(repoPath, 'task-empty', 'feat: empty')
+
+    createTask(db, { id: 'task-empty', title: 'Empty task' })
+    updateTask(db, 'task-empty', {
+      status: 'in_progress',
+      worktree_path: info.path,
+      branch: info.branch,
+      head_sha: info.headSha,
+      repo_path: repoPath,
+      agent_id: 'w-empty',
+    })
+    registerAgent(db, { id: 'w-empty', task_id: 'task-empty' })
+
+    await handleReportDone(db, 'task-empty', 'done')
+
+    const emptyTask = getTask(db, 'task-empty')
+    expect(emptyTask?.failure_reason).toBe('task branch has no commits')
+
+    // Now set up a conflict scenario using the fallback mc/integration branch
+    await ensureIntegrationBranch(repoPath)
+    const integBranch = 'mc/integration'
+    const origBranch = execSync('git branch --show-current', { cwd: repoPath }).toString().trim()
+    execSync(`git checkout ${integBranch}`, { cwd: repoPath })
+    writeFileSync(join(repoPath, 'x.ts'), 'integ')
+    execSync('git add . && git commit -m "integ"', { cwd: repoPath })
+    execSync(`git checkout ${origBranch}`, { cwd: repoPath })
+
+    const info2 = await createWorktree(repoPath, 'task-conflict', 'feat: conflict')
+
+    createTask(db, { id: 'task-conflict', title: 'Conflict task' })
+    updateTask(db, 'task-conflict', {
+      status: 'in_progress',
+      worktree_path: info2.path,
+      branch: info2.branch,
+      head_sha: info2.headSha,
+      repo_path: repoPath,
+      agent_id: 'w-conflict',
+    })
+    registerAgent(db, { id: 'w-conflict', task_id: 'task-conflict' })
+
+    writeFileSync(join(info2.path, 'x.ts'), 'worker')
+    execSync('git add . && git commit -m "worker"', { cwd: info2.path })
+
+    await handleReportDone(db, 'task-conflict', 'done')
+
+    const conflictTask = getTask(db, 'task-conflict')
+    expect(conflictTask?.failure_reason).toBe('merge conflict')
+
+    // The two reasons are distinct
+    expect(emptyTask?.failure_reason).not.toBe(conflictTask?.failure_reason)
+  })
+})

--- a/tests/git/worktree-isolation.test.ts
+++ b/tests/git/worktree-isolation.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createWorktree, removeWorktree, readWorktreeGitDir } from '../../src/git/worktree.js'
+import { buildWorkerEnv } from '../../src/spawner/index.js'
+import { ensureIntegrationBranch, mergeWorktreeBranch } from '../../src/git/merge.js'
+import { execSync } from 'child_process'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+describe('worktree commit isolation', () => {
+  let parentRepo: string
+
+  beforeEach(() => {
+    parentRepo = mkdtempSync(join(tmpdir(), 'mc-isolation-test-'))
+    execSync('git init', { cwd: parentRepo })
+    execSync('git config user.email "test@test.com"', { cwd: parentRepo })
+    execSync('git config user.name "Test"', { cwd: parentRepo })
+    execSync('echo "init" > README.md && git add . && git commit -m "init"', { cwd: parentRepo })
+  })
+
+  afterEach(() => {
+    rmSync(parentRepo, { recursive: true, force: true })
+  })
+
+  it('createWorktree returns gitDir pointing to parent .git/worktrees/', async () => {
+    const info = await createWorktree(parentRepo, 'iso-1', 'feat: isolation test')
+    expect(info.gitDir).toContain('.git/worktrees/')
+    const isDir = execSync(`test -d "${info.gitDir}" && echo yes || echo no`).toString().trim()
+    expect(isDir).toBe('yes')
+    await removeWorktree(parentRepo, info)
+  })
+
+  it('createWorktree returns headSha matching base branch HEAD', async () => {
+    const parentHead = execSync('git rev-parse HEAD', { cwd: parentRepo }).toString().trim()
+    const info = await createWorktree(parentRepo, 'iso-2', 'feat: head check')
+    expect(info.headSha).toBe(parentHead)
+    await removeWorktree(parentRepo, info)
+  })
+
+  it('readWorktreeGitDir parses the .git file correctly', async () => {
+    const info = await createWorktree(parentRepo, 'iso-3')
+    const gitDir = readWorktreeGitDir(info.path)
+    expect(gitDir).toBe(info.gitDir)
+    const dotGitContent = readFileSync(join(info.path, '.git'), 'utf8')
+    expect(dotGitContent).toContain('gitdir:')
+    await removeWorktree(parentRepo, info)
+  })
+
+  it('with isolation env vars, git commit from worktree lands on task branch', async () => {
+    const info = await createWorktree(parentRepo, 'iso-4', 'feat: commit test')
+    const env = buildWorkerEnv('w-iso-4', { worktreePath: info.path, gitDir: info.gitDir })
+
+    writeFileSync(join(info.path, 'feature.ts'), 'export const x = 1')
+    execSync('git add feature.ts && git commit -m "add feature"', { cwd: info.path, env })
+
+    const branchLog = execSync(`git log --oneline ${info.branch}`, { cwd: parentRepo }).toString()
+    expect(branchLog).toContain('add feature')
+
+    const parentBranch = execSync('git branch --show-current', { cwd: parentRepo }).toString().trim()
+    const parentLog = execSync(`git log --oneline ${parentBranch}`, { cwd: parentRepo }).toString()
+    expect(parentLog).not.toContain('add feature')
+
+    await removeWorktree(parentRepo, info)
+  })
+
+  it('with isolation env vars, git operations from PARENT repo cwd still target worktree', async () => {
+    const info = await createWorktree(parentRepo, 'iso-5', 'feat: cwd isolation')
+    const env = buildWorkerEnv('w-iso-5', { worktreePath: info.path, gitDir: info.gitDir })
+
+    writeFileSync(join(info.path, 'isolated.ts'), 'export const isolated = true')
+
+    // Run git commands from the PARENT repo's directory with isolation env vars —
+    // GIT_DIR + GIT_WORK_TREE force git to operate on the worktree, not the parent
+    execSync('git add -A && git commit -m "isolated commit"', { cwd: parentRepo, env })
+
+    const worktreeBranchLog = execSync(`git log --oneline ${info.branch}`, { cwd: parentRepo }).toString()
+    expect(worktreeBranchLog).toContain('isolated commit')
+
+    const parentBranch = execSync('git branch --show-current', { cwd: parentRepo }).toString().trim()
+    const parentLog = execSync(`git log --oneline ${parentBranch}`, { cwd: parentRepo }).toString()
+    expect(parentLog).not.toContain('isolated commit')
+
+    await removeWorktree(parentRepo, info)
+  })
+
+  it('without isolation env vars, git commands from parent cwd affect parent branch (demonstrates the bug)', async () => {
+    await createWorktree(parentRepo, 'iso-6', 'feat: no isolation')
+
+    writeFileSync(join(parentRepo, 'parent-file.ts'), 'export const parent = true')
+    execSync('git add parent-file.ts && git commit -m "parent commit"', { cwd: parentRepo })
+
+    const parentBranch = execSync('git branch --show-current', { cwd: parentRepo }).toString().trim()
+    const parentLog = execSync(`git log --oneline ${parentBranch}`, { cwd: parentRepo }).toString()
+    expect(parentLog).toContain('parent commit')
+  })
+
+  it('merge into mc/run-<runId> still works after worktree commits with isolation', async () => {
+    const runId = 'iso-run-1'
+    await ensureIntegrationBranch(parentRepo, runId)
+
+    const info = await createWorktree(parentRepo, 'iso-7', 'feat: merge test')
+    const env = buildWorkerEnv('w-iso-7', { worktreePath: info.path, gitDir: info.gitDir })
+
+    writeFileSync(join(info.path, 'merge-feature.ts'), 'export const merge = true')
+    execSync('git add merge-feature.ts && git commit -m "merge test commit"', { cwd: info.path, env })
+
+    await mergeWorktreeBranch(parentRepo, info.branch, runId)
+
+    const files = execSync(`git show mc/run-${runId}:merge-feature.ts`, { cwd: parentRepo }).toString()
+    expect(files).toContain('export const merge = true')
+
+    await removeWorktree(parentRepo, info)
+  })
+
+  it('worktree branch naming still works correctly with gitDir/headSha fields', async () => {
+    const info1 = await createWorktree(parentRepo, 'iso-branch-1', 'feat: branch naming')
+    const info2 = await createWorktree(parentRepo, 'iso-branch-2', 'fix: another bug')
+
+    expect(info1.branch).toBe('feature/branch-naming-1')
+    expect(info2.branch).toBe('fix/another-bug-2')
+    expect(info1.gitDir).toBeTruthy()
+    expect(info2.gitDir).toBeTruthy()
+    expect(info1.headSha).toBeTruthy()
+    expect(info2.headSha).toBeTruthy()
+
+    await removeWorktree(parentRepo, info1)
+    await removeWorktree(parentRepo, info2)
+  })
+
+  it('headSha tracks the correct base when baseBranch is specified', async () => {
+    execSync('git checkout -b dev', { cwd: parentRepo })
+    writeFileSync(join(parentRepo, 'dev.ts'), 'export const dev = true')
+    execSync('git add . && git commit -m "dev commit"', { cwd: parentRepo })
+    const devHead = execSync('git rev-parse HEAD', { cwd: parentRepo }).toString().trim()
+    execSync('git checkout -', { cwd: parentRepo })
+
+    const info = await createWorktree(parentRepo, 'iso-base', 'feat: based on dev', 'dev')
+    expect(info.headSha).toBe(devHead)
+
+    await removeWorktree(parentRepo, info)
+  })
+})

--- a/tests/spawner/agent-process-verification.test.ts
+++ b/tests/spawner/agent-process-verification.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createDb, closeDb } from '../../src/server/state/db.js'
+import { createTask, getTask, updateTask } from '../../src/server/state/tasks.js'
+import { registerAgent, updateAgent, getAgent } from '../../src/server/state/agents.js'
+import { checkStuckWorkers, AGENT_NEVER_STARTED_REASON } from '../../src/spawner/stuck-watcher.js'
+import type Database from 'better-sqlite3'
+
+function minutesAgo(minutes: number): string {
+  return new Date(Date.now() - minutes * 60_000).toISOString()
+}
+
+function secondsAgo(seconds: number): string {
+  return new Date(Date.now() - seconds * 1000).toISOString()
+}
+
+describe('agent process verification: never-started path', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = createDb(':memory:')
+    // Task in_progress, agent still spawning (never called get_my_task)
+    db.prepare(
+      "INSERT INTO tasks (id, title, status, started_at) VALUES ('t1', 'Test', 'in_progress', ?)"
+    ).run(secondsAgo(70)) // started 70s ago
+    db.prepare(
+      "INSERT INTO agents (id, task_id, status) VALUES ('a1', 't1', 'spawning')"
+    ).run()
+  })
+
+  afterEach(() => {
+    closeDb(db)
+  })
+
+  it('marks task and agent failed when spawning agent has no logs after firstActivitySeconds', () => {
+    const stuckSince = new Map<string, number>()
+    checkStuckWorkers(db, stuckSince, 5, 10, Date.now(), () => '', () => {}, 60)
+
+    const task = db.prepare("SELECT status FROM tasks WHERE id = 't1'").get() as { status: string }
+    const agent = db.prepare("SELECT status FROM agents WHERE id = 'a1'").get() as { status: string }
+    expect(task.status).toBe('failed')
+    expect(agent.status).toBe('failed')
+  })
+
+  it('writes the canonical AGENT_NEVER_STARTED_REASON to logs', () => {
+    const stuckSince = new Map<string, number>()
+    checkStuckWorkers(db, stuckSince, 5, 10, Date.now(), () => '', () => {}, 60)
+
+    const logs = db.prepare(
+      "SELECT message FROM logs WHERE task_id = 't1' AND level = 'error'"
+    ).all() as { message: string }[]
+    expect(logs).toHaveLength(1)
+    expect(logs[0].message).toBe(AGENT_NEVER_STARTED_REASON)
+  })
+
+  it('kills the tmux window when agent never started', () => {
+    db.prepare("UPDATE agents SET tmux_pane = '@99' WHERE id = 'a1'").run()
+    const killed: string[] = []
+    const stuckSince = new Map<string, number>()
+    checkStuckWorkers(db, stuckSince, 5, 10, Date.now(), () => '', (id) => killed.push(id), 60)
+
+    expect(killed).toEqual(['@99'])
+  })
+
+  it('does not trigger before firstActivitySeconds elapses', () => {
+    // started only 30s ago — not yet past the 60s heartbeat
+    db.prepare("UPDATE tasks SET started_at = ? WHERE id = 't1'").run(secondsAgo(30))
+
+    const stuckSince = new Map<string, number>()
+    checkStuckWorkers(db, stuckSince, 5, 10, Date.now(), () => '', () => {}, 60)
+
+    const task = db.prepare("SELECT status FROM tasks WHERE id = 't1'").get() as { status: string }
+    expect(task.status).toBe('in_progress') // too early to fail
+  })
+
+  it('does not trigger when spawning agent already has log entries', () => {
+    // Even if agent is spawning, if it wrote a log it's doing something
+    db.prepare(
+      "INSERT INTO logs (task_id, level, message) VALUES ('t1', 'info', 'progress update')"
+    ).run()
+
+    const stuckSince = new Map<string, number>()
+    checkStuckWorkers(db, stuckSince, 5, 10, Date.now(), () => '', () => {}, 60)
+
+    const task = db.prepare("SELECT status FROM tasks WHERE id = 't1'").get() as { status: string }
+    expect(task.status).toBe('in_progress') // has logs — not treated as never-started
+  })
+
+  it('does not re-trigger when task is already failed', () => {
+    db.prepare("UPDATE tasks SET status = 'failed' WHERE id = 't1'").run()
+
+    const stuckSince = new Map<string, number>()
+    checkStuckWorkers(db, stuckSince, 5, 10, Date.now(), () => '', () => {}, 60)
+
+    // Should not write any extra logs
+    const logs = db.prepare("SELECT * FROM logs WHERE task_id = 't1'").all()
+    expect(logs).toHaveLength(0)
+  })
+})
+
+describe('agent process verification: started-then-died path stays distinguishable', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = createDb(':memory:')
+  })
+
+  afterEach(() => {
+    closeDb(db)
+  })
+
+  it('started-then-died agent has a different failure message than never-started', () => {
+    // Simulate: agent started (status 'running'), wrote a log, then died (status 'failed')
+    db.prepare(
+      "INSERT INTO tasks (id, title, status, started_at) VALUES ('t1', 'Test', 'failed', ?)"
+    ).run(minutesAgo(2))
+    db.prepare(
+      "INSERT INTO agents (id, task_id, status) VALUES ('a1', 't1', 'failed')"
+    ).run()
+    // The agent DID write a progress log before dying — this is NOT never-started
+    db.prepare(
+      "INSERT INTO logs (task_id, level, message) VALUES ('t1', 'info', 'Task started, working on implementation')"
+    ).run()
+    // The failure is recorded without AGENT_NEVER_STARTED_REASON
+    db.prepare(
+      "INSERT INTO logs (task_id, level, message) VALUES ('t1', 'error', 'worker exited unexpectedly')"
+    ).run()
+
+    const errorLogs = db.prepare(
+      "SELECT message FROM logs WHERE task_id = 't1' AND level = 'error'"
+    ).all() as { message: string }[]
+
+    expect(errorLogs).toHaveLength(1)
+    expect(errorLogs[0].message).not.toBe(AGENT_NEVER_STARTED_REASON)
+    expect(errorLogs[0].message).toBe('worker exited unexpectedly')
+  })
+
+  it('never-started path writes exactly AGENT_NEVER_STARTED_REASON, not a generic timeout message', () => {
+    db.prepare(
+      "INSERT INTO tasks (id, title, status, started_at) VALUES ('t1', 'Test', 'in_progress', ?)"
+    ).run(secondsAgo(90))
+    db.prepare(
+      "INSERT INTO agents (id, task_id, status) VALUES ('a1', 't1', 'spawning')"
+    ).run()
+
+    const stuckSince = new Map<string, number>()
+    checkStuckWorkers(db, stuckSince, 5, 10, Date.now(), () => '', () => {}, 60)
+
+    const errorLogs = db.prepare(
+      "SELECT message FROM logs WHERE task_id = 't1' AND level = 'error'"
+    ).all() as { message: string }[]
+
+    expect(errorLogs).toHaveLength(1)
+    expect(errorLogs[0].message).toBe(AGENT_NEVER_STARTED_REASON)
+    // Must NOT look like the general timeout message
+    expect(errorLogs[0].message).not.toContain('timed out after')
+  })
+
+  it('running agent with old log is caught by general staleness (not never-started)', () => {
+    // An agent that DID start (status 'running') but has been quiet too long
+    // should get the timed-out message, NOT the never-started reason
+    db.prepare(
+      "INSERT INTO tasks (id, title, status, started_at) VALUES ('t1', 'Test', 'in_progress', ?)"
+    ).run(minutesAgo(15))
+    db.prepare(
+      "INSERT INTO agents (id, task_id, status) VALUES ('a1', 't1', 'running')"
+    ).run()
+    // Has a log from 12 minutes ago (past both warning and timeout)
+    db.prepare(
+      "INSERT INTO logs (task_id, level, message, created_at) VALUES ('t1', 'info', 'started', ?)"
+    ).run(minutesAgo(12))
+
+    const stuckSince = new Map<string, number>()
+    checkStuckWorkers(db, stuckSince, 5, 10, Date.now(), () => 'idle', () => {}, 60)
+
+    const errorLogs = db.prepare(
+      "SELECT message FROM logs WHERE task_id = 't1' AND level = 'error'"
+    ).all() as { message: string }[]
+
+    expect(errorLogs).toHaveLength(1)
+    expect(errorLogs[0].message).toContain('timed out after')
+    expect(errorLogs[0].message).not.toBe(AGENT_NEVER_STARTED_REASON)
+  })
+})
+
+describe('agent process verification: first-activity heartbeat parameter', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = createDb(':memory:')
+    db.prepare(
+      "INSERT INTO tasks (id, title, status, started_at) VALUES ('t1', 'Test', 'in_progress', ?)"
+    ).run(secondsAgo(45))
+    db.prepare(
+      "INSERT INTO agents (id, task_id, status) VALUES ('a1', 't1', 'spawning')"
+    ).run()
+  })
+
+  afterEach(() => {
+    closeDb(db)
+  })
+
+  it('respects a custom firstActivitySeconds threshold', () => {
+    // started 45s ago; default threshold is 60s so would NOT trigger
+    const stuckSince = new Map<string, number>()
+    checkStuckWorkers(db, stuckSince, 5, 10, Date.now(), () => '', () => {}, 60)
+    const task1 = db.prepare("SELECT status FROM tasks WHERE id = 't1'").get() as { status: string }
+    expect(task1.status).toBe('in_progress') // not yet past 60s
+
+    // Lower threshold to 30s — now 45s elapsed should trigger
+    db.prepare("UPDATE tasks SET status = 'in_progress' WHERE id = 't1'").run()
+    db.prepare("UPDATE agents SET status = 'spawning' WHERE id = 'a1'").run()
+    checkStuckWorkers(db, stuckSince, 5, 10, Date.now(), () => '', () => {}, 30)
+    const task2 = db.prepare("SELECT status FROM tasks WHERE id = 't1'").get() as { status: string }
+    expect(task2.status).toBe('failed')
+  })
+
+  it('does not check spawning agents under the running-agent staleness path', () => {
+    // spawning agents should not produce "timed out after Xm" messages
+    db.prepare("UPDATE tasks SET started_at = ? WHERE id = 't1'").run(minutesAgo(15))
+
+    const stuckSince = new Map<string, number>()
+    // Use a very high firstActivitySeconds so heartbeat doesn't trigger
+    checkStuckWorkers(db, stuckSince, 5, 10, Date.now(), () => '', () => {}, 9999)
+
+    const allLogs = db.prepare("SELECT * FROM logs WHERE task_id = 't1'").all()
+    expect(allLogs).toHaveLength(0) // spawning agents skipped by running-agent path
+  })
+})

--- a/tests/spawner/backend.test.ts
+++ b/tests/spawner/backend.test.ts
@@ -7,11 +7,12 @@ import type { RuntimeBackend, WorkerHandle } from '../../src/spawner/backend.js'
 vi.mock('../../src/spawner/tmux.js', () => ({
   spawnTmuxWorker: vi.fn(() => ({
     pid: undefined,
-    tmuxPane: 'multiclaude:mc-task-1',
+    tmuxPane: '@1',
     onExit: vi.fn(),
     onError: vi.fn(),
   })),
   captureTmuxPane: vi.fn(() => ''),
+  killTmuxWindow: vi.fn(),
 }))
 
 describe('RuntimeBackend interface', () => {
@@ -67,14 +68,14 @@ describe('WorkerHandle shape', () => {
     expect(typeof handle.onError).toBe('function')
   })
 
-  it('tmuxPane is optional and carries the window target', () => {
+  it('tmuxPane is optional and carries the @NN window ID', () => {
     const handle: WorkerHandle = {
       pid: undefined,
-      tmuxPane: 'multiclaude:mc-my-task',
+      tmuxPane: '@42',
       onExit: () => {},
       onError: () => {},
     }
-    expect(handle.tmuxPane).toBe('multiclaude:mc-my-task')
+    expect(handle.tmuxPane).toBe('@42')
   })
 
   it('pid can be undefined (spawn failure)', () => {

--- a/tests/spawner/index.test.ts
+++ b/tests/spawner/index.test.ts
@@ -138,6 +138,37 @@ describe('spawner', () => {
     else process.env['CLAUDECODE'] = orig
   })
 
+  it('buildWorkerEnv sets GIT_DIR, GIT_WORK_TREE, GIT_CEILING_DIRECTORIES when isolation provided', () => {
+    const env = buildWorkerEnv('w-task-1', {
+      worktreePath: '/tmp/mc-task-1-abcdef',
+      gitDir: '/repos/.git/worktrees/mc-task-1-abcdef',
+    })
+    expect(env.GIT_DIR).toBe('/repos/.git/worktrees/mc-task-1-abcdef')
+    expect(env.GIT_WORK_TREE).toBe('/tmp/mc-task-1-abcdef')
+    expect(env.GIT_CEILING_DIRECTORIES).toBe('/tmp')
+  })
+
+  it('buildWorkerEnv omits git isolation vars when no isolation provided', () => {
+    const saved = {
+      GIT_DIR: process.env.GIT_DIR,
+      GIT_WORK_TREE: process.env.GIT_WORK_TREE,
+      GIT_CEILING_DIRECTORIES: process.env.GIT_CEILING_DIRECTORIES,
+    }
+    delete process.env.GIT_DIR
+    delete process.env.GIT_WORK_TREE
+    delete process.env.GIT_CEILING_DIRECTORIES
+    try {
+      const env = buildWorkerEnv('w-task-1')
+      expect(env.GIT_DIR).toBeUndefined()
+      expect(env.GIT_WORK_TREE).toBeUndefined()
+      expect(env.GIT_CEILING_DIRECTORIES).toBeUndefined()
+    } finally {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v !== undefined) (process.env as Record<string, string>)[k] = v
+      }
+    }
+  })
+
   it('buildWorkerArgs omits --effort when effort is unset (high is the default)', () => {
     const cfg: SpawnConfig = {
       taskId: 'task-1',

--- a/tests/spawner/stuck-watcher.test.ts
+++ b/tests/spawner/stuck-watcher.test.ts
@@ -284,4 +284,54 @@ describe('checkStuckWorkers', () => {
 
     expect(captureCallCount.n).toBe(0) // no capture attempted
   })
+
+  // --- window reaping on timeout ---
+
+  it('kills the tmux window when a task times out', () => {
+    db.prepare(
+      "INSERT INTO logs (task_id, level, message, created_at) VALUES ('t1', 'info', 'old', ?)"
+    ).run(minutesAgo(TIMEOUT_MINUTES + 1))
+    db.prepare("UPDATE agents SET tmux_pane = '@42' WHERE id = 'a1'").run()
+
+    const killed: string[] = []
+    const mockKill = (windowId: string) => { killed.push(windowId) }
+
+    const stuckSince = new Map<string, number>()
+    const mockCapture = (_target: string, _lines: number) => 'idle'
+    checkStuckWorkers(db, stuckSince, WARNING_MINUTES, TIMEOUT_MINUTES, Date.now(), mockCapture, mockKill)
+
+    expect(killed).toHaveLength(1)
+    expect(killed[0]).toBe('@42')
+  })
+
+  it('does not kill a window when the task only triggers a warning (not timeout)', () => {
+    db.prepare(
+      "INSERT INTO logs (task_id, level, message, created_at) VALUES ('t1', 'info', 'old', ?)"
+    ).run(minutesAgo(WARNING_MINUTES + 1))
+    db.prepare("UPDATE agents SET tmux_pane = '@42' WHERE id = 'a1'").run()
+
+    const killed: string[] = []
+    const mockKill = (windowId: string) => { killed.push(windowId) }
+
+    const stuckSince = new Map<string, number>()
+    const mockCapture = (_target: string, _lines: number) => 'idle'
+    checkStuckWorkers(db, stuckSince, WARNING_MINUTES, TIMEOUT_MINUTES, Date.now(), mockCapture, mockKill)
+
+    expect(killed).toHaveLength(0)
+  })
+
+  it('does not kill a window when the agent has no tmux_pane', () => {
+    db.prepare(
+      "INSERT INTO logs (task_id, level, message, created_at) VALUES ('t1', 'info', 'old', ?)"
+    ).run(minutesAgo(TIMEOUT_MINUTES + 1))
+    // agent has no tmux_pane (default NULL)
+
+    const killed: string[] = []
+    const mockKill = (windowId: string) => { killed.push(windowId) }
+
+    const stuckSince = new Map<string, number>()
+    checkStuckWorkers(db, stuckSince, WARNING_MINUTES, TIMEOUT_MINUTES, Date.now(), undefined, mockKill)
+
+    expect(killed).toHaveLength(0)
+  })
 })

--- a/tests/spawner/tmux.test.ts
+++ b/tests/spawner/tmux.test.ts
@@ -28,6 +28,7 @@ import {
   writeLaunchScript,
   captureTmuxPane,
   spawnTmuxWorker,
+  killTmuxWindow,
 } from '../../src/spawner/tmux.js'
 
 describe('ensureTmuxSession', () => {
@@ -87,21 +88,48 @@ describe('createTmuxWindow', () => {
     mockExecSync.mockReset()
   })
 
-  it('calls tmux new-window with correct session, name and cwd', () => {
-    mockExecSync.mockReturnValueOnce(undefined)
-    const target = createTmuxWindow('my-session', 'task-1', '/tmp/worktree')
-    expect(target).toBe('my-session:mc-task-1')
+  it('calls tmux new-window with -P -F #{window_id} and returns @NN ID', () => {
+    mockExecSync.mockReturnValueOnce('@42\n')
+    const windowId = createTmuxWindow('my-session', 'mc-w-task-1', '/tmp/worktree')
+    expect(windowId).toBe('@42')
     const call = mockExecSync.mock.calls[0][0] as string
     expect(call).toContain('new-window')
-    expect(call).toContain('-d')
-    expect(call).toContain('mc-task-1')
+    expect(call).toContain('-P')
+    expect(call).toContain('#{window_id}')
+    expect(call).toContain('mc-w-task-1')
     expect(call).toContain('/tmp/worktree')
   })
 
-  it('uses mc- prefix for window name', () => {
+  it('passes the exact windowName to tmux (caller controls the name)', () => {
+    mockExecSync.mockReturnValueOnce('@7\n')
+    const windowId = createTmuxWindow('sess', 'mc-w-my-task-retry1', '/path')
+    expect(windowId).toBe('@7')
+    const call = mockExecSync.mock.calls[0][0] as string
+    expect(call).toContain('mc-w-my-task-retry1')
+  })
+
+  it('throws when tmux returns an empty window ID', () => {
+    mockExecSync.mockReturnValueOnce('\n')
+    expect(() => createTmuxWindow('sess', 'mc-w-task', '/path')).toThrow(/Failed to get window ID/)
+  })
+})
+
+describe('killTmuxWindow', () => {
+  beforeEach(() => {
+    mockExecSync.mockReset()
+  })
+
+  it('calls tmux kill-window with the given window ID', () => {
     mockExecSync.mockReturnValueOnce(undefined)
-    const target = createTmuxWindow('sess', 'my-task', '/path')
-    expect(target).toContain('mc-my-task')
+    killTmuxWindow('@42')
+    const call = mockExecSync.mock.calls[0][0] as string
+    expect(call).toContain('kill-window')
+    expect(call).toContain('@42')
+  })
+
+  it('silently ignores errors when window is already dead', () => {
+    mockExecSync.mockImplementationOnce(() => { throw new Error('no such window') })
+    expect(() => killTmuxWindow('@42')).not.toThrow()
   })
 })
 
@@ -255,27 +283,26 @@ describe('spawnTmuxWorker', () => {
     mcpConfigPath: '/tmp/mcp.json',
   }
 
+  // Helper: sets up the standard 4-call mock sequence (not-in-tmux path)
+  // 1. has-session (ensureTmuxSession)
+  // 2. new-window -P -F #{window_id} (createTmuxWindow → returns windowId)
+  // 3. display-message pane_pid (getTmuxPanePid)
+  // 4. send-keys (sendTmuxKeys)
+  function setupDefaultMocks({ windowId = '@42', pid = '9999\n' } = {}) {
+    mockExecSync.mockReset()
+    mockExecSync.mockReturnValueOnce(undefined)     // has-session succeeds
+    mockExecSync.mockReturnValueOnce(`${windowId}\n`) // new-window returns @NN
+    mockExecSync.mockReturnValueOnce(pid)            // pane PID
+    mockExecSync.mockReturnValueOnce(undefined)      // send-keys
+  }
+
   beforeEach(() => {
     mockExecSync.mockReset()
     mockSpawn.mockReset()
     mockWriteFileSync.mockReset()
     mockMkdirSync.mockReset()
-
-    // Default stubs for the full spawn sequence:
-    // 1. ensureTmuxSession (inside tmux check) — return session name
-    mockExecSync.mockReturnValueOnce('multiclaude\n')
-    // (Not inside $TMUX; has-session succeeds so no new-session call)
-    // 2. createTmuxWindow — succeeds silently
-    mockExecSync.mockReturnValueOnce(undefined)
-    // 3. getTmuxPanePid — returns a PID
-    mockExecSync.mockReturnValueOnce('9999\n')
-    // 4. sendTmuxKeys — send the launch script command
-    mockExecSync.mockReturnValueOnce(undefined)
-
-    // Monitor spawn
+    setupDefaultMocks()
     mockSpawn.mockReturnValue({ on: vi.fn(), unref: vi.fn() })
-
-    // Ensure not inside tmux for deterministic session path
     delete process.env.TMUX
   })
 
@@ -283,25 +310,45 @@ describe('spawnTmuxWorker', () => {
     delete process.env.TMUX
   })
 
-  it('returns a WorkerHandle with tmuxPane set to session:mc-<taskId>', () => {
-    // ensureTmuxSession: has-session succeeds → 'multiclaude'
-    mockExecSync.mockReset()
-    mockExecSync.mockReturnValueOnce(undefined)    // has-session succeeds
-    mockExecSync.mockReturnValueOnce(undefined)    // new-window
-    mockExecSync.mockReturnValueOnce('9999\n')     // pane PID
-    mockExecSync.mockReturnValueOnce(undefined)    // send-keys
-
+  it('returns a WorkerHandle with tmuxPane set to the @NN window ID', () => {
+    setupDefaultMocks({ windowId: '@42' })
     const handle = spawnTmuxWorker(cfg)
-    expect(handle.tmuxPane).toBe('multiclaude:mc-task-42')
+    expect(handle.tmuxPane).toBe('@42')
+  })
+
+  it('uses a unique window name per agent (mc-<agentId>)', () => {
+    setupDefaultMocks()
+    spawnTmuxWorker(cfg)
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string)
+    const newWindowCall = calls.find(c => c.includes('new-window'))
+    expect(newWindowCall).toBeDefined()
+    // Window name should embed the agentId, not just the taskId
+    expect(newWindowCall).toContain('mc-w-task-42')
+  })
+
+  it('different agentIds produce different window names', () => {
+    const windowNames: string[] = []
+    for (const agentId of ['w-task-1', 'w-task-1-retry1', 'w-task-1-retry2']) {
+      mockExecSync.mockReset()
+      mockExecSync.mockReturnValueOnce(undefined)    // has-session
+      mockExecSync.mockReturnValueOnce('@99\n')       // new-window
+      mockExecSync.mockReturnValueOnce('1234\n')     // pane PID
+      mockExecSync.mockReturnValueOnce(undefined)    // send-keys
+      mockSpawn.mockReturnValue({ on: vi.fn(), unref: vi.fn() })
+      spawnTmuxWorker({ ...cfg, agentId })
+      const calls = mockExecSync.mock.calls.map(c => c[0] as string)
+      const newWindowCall = calls.find(c => c.includes('new-window'))!
+      // Extract the -n 'mc-...' part
+      const match = newWindowCall.match(/-n '([^']+)'/)
+      windowNames.push(match?.[1] ?? '')
+      mockExecSync.mockReset()
+    }
+    // All three window names must be unique
+    expect(new Set(windowNames).size).toBe(3)
   })
 
   it('sets pid from getTmuxPanePid output', () => {
-    mockExecSync.mockReset()
-    mockExecSync.mockReturnValueOnce(undefined)    // has-session
-    mockExecSync.mockReturnValueOnce(undefined)    // new-window
-    mockExecSync.mockReturnValueOnce('12345\n')    // pane PID
-    mockExecSync.mockReturnValueOnce(undefined)    // send-keys
-
+    setupDefaultMocks({ pid: '12345\n' })
     const handle = spawnTmuxWorker(cfg)
     expect(handle.pid).toBe(12345)
   })
@@ -309,7 +356,7 @@ describe('spawnTmuxWorker', () => {
   it('pid is undefined when getTmuxPanePid fails', () => {
     mockExecSync.mockReset()
     mockExecSync.mockReturnValueOnce(undefined)                              // has-session
-    mockExecSync.mockReturnValueOnce(undefined)                              // new-window
+    mockExecSync.mockReturnValueOnce('@42\n')                                // new-window
     mockExecSync.mockImplementationOnce(() => { throw new Error('nopid') }) // pane PID fails
     mockExecSync.mockReturnValueOnce(undefined)                              // send-keys
 
@@ -317,62 +364,38 @@ describe('spawnTmuxWorker', () => {
     expect(handle.pid).toBeUndefined()
   })
 
-  it('spawns a tmux wait-for monitor process for the exit signal', () => {
-    mockExecSync.mockReset()
-    mockExecSync.mockReturnValueOnce(undefined)  // has-session
-    mockExecSync.mockReturnValueOnce(undefined)  // new-window
-    mockExecSync.mockReturnValueOnce('9999\n')   // PID
-    mockExecSync.mockReturnValueOnce(undefined)  // send-keys
-
+  it('spawns a tmux wait-for monitor using the agentId in the signal name', () => {
+    setupDefaultMocks()
     spawnTmuxWorker(cfg)
-
     expect(mockSpawn).toHaveBeenCalledWith(
       'tmux',
-      ['wait-for', 'mc-task-42-exit'],
+      ['wait-for', 'mc-w-task-42-exit'],
       expect.objectContaining({ stdio: 'ignore', detached: false })
     )
   })
 
-  it('sends the launch script to the pane via send-keys', () => {
-    mockExecSync.mockReset()
-    mockExecSync.mockReturnValueOnce(undefined)  // has-session
-    mockExecSync.mockReturnValueOnce(undefined)  // new-window
-    mockExecSync.mockReturnValueOnce('9999\n')   // PID
-    mockExecSync.mockReturnValueOnce(undefined)  // send-keys
-
+  it('targets send-keys at the @NN window ID, not a name-based target', () => {
+    setupDefaultMocks({ windowId: '@42' })
     spawnTmuxWorker(cfg)
-
     const calls = mockExecSync.mock.calls.map(c => c[0] as string)
     const sendKeysCall = calls.find(c => c.includes('send-keys') && c.includes('worker-launch.sh'))
     expect(sendKeysCall).toBeDefined()
-    // Should include "Enter" to execute the command
+    expect(sendKeysCall).toContain('@42')
     expect(sendKeysCall).toContain('Enter')
   })
 
   it('appends tmux wait-for signal to the send-keys command', () => {
-    mockExecSync.mockReset()
-    mockExecSync.mockReturnValueOnce(undefined)  // has-session
-    mockExecSync.mockReturnValueOnce(undefined)  // new-window
-    mockExecSync.mockReturnValueOnce('9999\n')   // PID
-    mockExecSync.mockReturnValueOnce(undefined)  // send-keys
-
+    setupDefaultMocks()
     spawnTmuxWorker(cfg)
-
     const calls = mockExecSync.mock.calls.map(c => c[0] as string)
     const sendKeysCall = calls.find(c => c.includes('send-keys'))
     expect(sendKeysCall).toContain('wait-for -S')
-    expect(sendKeysCall).toContain('mc-task-42-exit')
+    expect(sendKeysCall).toContain('mc-w-task-42-exit')
   })
 
   it('writes settings.local.json before spawning', () => {
-    mockExecSync.mockReset()
-    mockExecSync.mockReturnValueOnce(undefined)  // has-session
-    mockExecSync.mockReturnValueOnce(undefined)  // new-window
-    mockExecSync.mockReturnValueOnce('9999\n')   // PID
-    mockExecSync.mockReturnValueOnce(undefined)  // send-keys
-
+    setupDefaultMocks()
     spawnTmuxWorker(cfg)
-
     const settingsCall = mockWriteFileSync.mock.calls.find(
       (c: unknown[]) => (c[0] as string).includes('settings.local.json')
     )
@@ -382,12 +405,7 @@ describe('spawnTmuxWorker', () => {
   })
 
   it('exposes onExit and onError via the monitor process events', () => {
-    mockExecSync.mockReset()
-    mockExecSync.mockReturnValueOnce(undefined)  // has-session
-    mockExecSync.mockReturnValueOnce(undefined)  // new-window
-    mockExecSync.mockReturnValueOnce('9999\n')   // PID
-    mockExecSync.mockReturnValueOnce(undefined)  // send-keys
-
+    setupDefaultMocks()
     const onMock = vi.fn()
     mockSpawn.mockReturnValue({ on: onMock, unref: vi.fn() })
 

--- a/tests/tools/orchestrator.test.ts
+++ b/tests/tools/orchestrator.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { z } from 'zod'
 import { createDb, closeDb } from '../../src/server/state/db.js'
-import { handlePlanDag, handleGetSystemStatus, handleWaitForEvent, handleCancelTask, handleSpawnWorker } from '../../src/server/tools/orchestrator.js'
+import { handlePlanDag, handleGetSystemStatus, handleWaitForEvent, handleCancelTask, handleSpawnWorker, normalizeEffort, VALID_EFFORT_VALUES } from '../../src/server/tools/orchestrator.js'
 import { addEdge } from '../../src/server/state/dag.js'
 import { execSync } from 'child_process'
 import { mkdtempSync, rmSync } from 'fs'
@@ -224,5 +224,69 @@ describe('orchestrator tools', () => {
     const elapsed = Date.now() - start
     expect(elapsed).toBeGreaterThanOrEqual(2000)
     expect(elapsed).toBeLessThan(4000)
+  })
+})
+
+describe('effort canonicalization', () => {
+  it('normalizeEffort returns canonical value for each valid effort', () => {
+    for (const v of VALID_EFFORT_VALUES) {
+      expect(normalizeEffort(v)).toBe(v)
+    }
+  })
+
+  it('normalizeEffort normalises "extra" alias to "xhigh"', () => {
+    expect(normalizeEffort('extra')).toBe('xhigh')
+  })
+
+  it('normalizeEffort returns null for invalid effort values', () => {
+    expect(normalizeEffort('turbo')).toBeNull()
+    expect(normalizeEffort('ultra')).toBeNull()
+    expect(normalizeEffort('')).toBeNull()
+    expect(normalizeEffort('HIGH')).toBeNull()
+  })
+
+  describe('plan_dag effort integration', () => {
+    let db: ReturnType<typeof createDb>
+
+    beforeEach(() => { db = createDb(':memory:') })
+    afterEach(() => { closeDb(db) })
+
+    it('stores "xhigh" when effort is explicitly set to "xhigh"', () => {
+      handlePlanDag(db, { tasks: [{ id: 't1', title: 'Task', effort: 'xhigh', dependsOn: [] }] })
+      const row = db.prepare('SELECT effort FROM tasks WHERE id = ?').get('t1') as { effort: string }
+      expect(row.effort).toBe('xhigh')
+    })
+
+    it('normalises "extra" to "xhigh" before writing the task record', () => {
+      handlePlanDag(db, { tasks: [{ id: 't1', title: 'Task', effort: 'extra', dependsOn: [] }] })
+      const row = db.prepare('SELECT effort FROM tasks WHERE id = ?').get('t1') as { effort: string }
+      expect(row.effort).toBe('xhigh')
+    })
+
+    it('returns an error for an invalid effort value naming the valid set', () => {
+      const result = handlePlanDag(db, { tasks: [{ id: 't1', title: 'Task', effort: 'turbo', dependsOn: [] }] })
+      expect('error' in result).toBe(true)
+      const { error } = result as { error: string }
+      expect(error).toContain('turbo')
+      expect(error).toContain('xhigh')
+      expect(error).toContain('low')
+      expect(error).toContain('max')
+    })
+
+    it('accepts all canonical effort values and stores them unchanged', () => {
+      const tasks = VALID_EFFORT_VALUES.map((v, i) => ({ id: `t${i}`, title: `Task ${v}`, effort: v, dependsOn: [] }))
+      const result = handlePlanDag(db, { tasks })
+      expect('visualization' in result).toBe(true)
+      for (const [i, v] of VALID_EFFORT_VALUES.entries()) {
+        const row = db.prepare('SELECT effort FROM tasks WHERE id = ?').get(`t${i}`) as { effort: string }
+        expect(row.effort).toBe(v)
+      }
+    })
+
+    it('does not write "extra" to the task record — always normalises to "xhigh"', () => {
+      handlePlanDag(db, { tasks: [{ id: 't1', title: 'Task', effort: 'extra', dependsOn: [] }] })
+      const row = db.prepare('SELECT effort FROM tasks WHERE id = ?').get('t1') as { effort: string }
+      expect(row.effort).not.toBe('extra')
+    })
   })
 })

--- a/tests/tools/orchestrator.test.ts
+++ b/tests/tools/orchestrator.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { z } from 'zod'
 import { createDb, closeDb } from '../../src/server/state/db.js'
-import { handlePlanDag, handleGetSystemStatus, handleWaitForEvent, handleCancelTask, handleSpawnWorker, normalizeEffort, VALID_EFFORT_VALUES } from '../../src/server/tools/orchestrator.js'
+import { handlePlanDag, handleGetSystemStatus, handleWaitForEvent, handleCancelTask, handleSpawnWorker, normalizeEffort, VALID_EFFORT_VALUES, enrichWithLastLog } from '../../src/server/tools/orchestrator.js'
 import { addEdge } from '../../src/server/state/dag.js'
 import { execSync } from 'child_process'
 import { mkdtempSync, rmSync } from 'fs'
@@ -288,5 +288,83 @@ describe('effort canonicalization', () => {
       const row = db.prepare('SELECT effort FROM tasks WHERE id = ?').get('t1') as { effort: string }
       expect(row.effort).not.toBe('extra')
     })
+  })
+})
+
+describe('last_log_at heartbeat field in system status', () => {
+  let db: ReturnType<typeof createDb>
+
+  beforeEach(() => { db = createDb(':memory:') })
+  afterEach(() => { closeDb(db) })
+
+  it('get_system_status includes last_log_at on each task', () => {
+    db.prepare("INSERT INTO tasks (id, title, status) VALUES ('t1', 'Task', 'in_progress')").run()
+    const status = handleGetSystemStatus(db, true)
+    expect(status.tasks).toHaveLength(1)
+    expect('last_log_at' in status.tasks[0]).toBe(true)
+  })
+
+  it('last_log_at is null when no log entries exist (agent merely registered)', () => {
+    db.prepare("INSERT INTO tasks (id, title, status) VALUES ('t1', 'Task', 'in_progress')").run()
+    const status = handleGetSystemStatus(db, true)
+    expect(status.tasks[0].last_log_at).toBeNull()
+  })
+
+  it('last_log_at reflects the most recent log entry timestamp', () => {
+    db.prepare("INSERT INTO tasks (id, title, status) VALUES ('t1', 'Task', 'in_progress')").run()
+    db.prepare(
+      "INSERT INTO logs (task_id, level, message, created_at) VALUES ('t1', 'info', 'started', '2026-01-01T10:00:00.000Z')"
+    ).run()
+    db.prepare(
+      "INSERT INTO logs (task_id, level, message, created_at) VALUES ('t1', 'info', 'progress', '2026-01-01T10:05:00.000Z')"
+    ).run()
+
+    const status = handleGetSystemStatus(db, true)
+    expect(status.tasks[0].last_log_at).toBe('2026-01-01T10:05:00.000Z')
+  })
+
+  it('last_log_at appears on retriableTasks as well', () => {
+    db.prepare(
+      "INSERT INTO tasks (id, title, status, retry_count, max_retries) VALUES ('t1', 'Task', 'failed', 0, 3)"
+    ).run()
+    db.prepare(
+      "INSERT INTO logs (task_id, level, message, created_at) VALUES ('t1', 'error', 'oops', '2026-01-01T09:00:00.000Z')"
+    ).run()
+
+    const status = handleGetSystemStatus(db, true)
+    expect(status.retriableTasks).toHaveLength(1)
+    expect(status.retriableTasks[0].last_log_at).toBe('2026-01-01T09:00:00.000Z')
+  })
+
+  it('enrichWithLastLog returns null for tasks with no logs', () => {
+    db.prepare("INSERT INTO tasks (id, title) VALUES ('t1', 'Task')").run()
+    const tasks = db.prepare('SELECT * FROM tasks').all() as Parameters<typeof enrichWithLastLog>[1]
+    const enriched = enrichWithLastLog(db, tasks)
+    expect(enriched[0].last_log_at).toBeNull()
+  })
+
+  it('enrichWithLastLog returns non-null for tasks with logs', () => {
+    db.prepare("INSERT INTO tasks (id, title) VALUES ('t1', 'Task')").run()
+    db.prepare(
+      "INSERT INTO logs (task_id, level, message) VALUES ('t1', 'info', 'doing work')"
+    ).run()
+    const tasks = db.prepare('SELECT * FROM tasks').all() as Parameters<typeof enrichWithLastLog>[1]
+    const enriched = enrichWithLastLog(db, tasks)
+    expect(enriched[0].last_log_at).not.toBeNull()
+  })
+
+  it('last_log_at is task-specific — different tasks have independent values', () => {
+    db.prepare("INSERT INTO tasks (id, title, status) VALUES ('t1', 'Task 1', 'in_progress')").run()
+    db.prepare("INSERT INTO tasks (id, title, status) VALUES ('t2', 'Task 2', 'in_progress')").run()
+    db.prepare(
+      "INSERT INTO logs (task_id, level, message, created_at) VALUES ('t1', 'info', 'progress', '2026-01-01T12:00:00.000Z')"
+    ).run()
+    // t2 has no logs
+
+    const status = handleGetSystemStatus(db, true)
+    const t1 = status.tasks.find(t => t.id === 't1')!
+    const t2 = status.tasks.find(t => t.id === 't2')!
+    expect(t1.last_log_at).toBe('2026-01-01T12:00:00.000Z')
+    expect(t2.last_log_at).toBeNull()
   })
 })

--- a/tests/tools/window-reaping.test.ts
+++ b/tests/tools/window-reaping.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for tmux window reaping on terminal task states:
+ * - done (via report_done)
+ * - cancelled (via cancel_task)
+ * - timed out (via stuck-watcher)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { mockKillTmuxWindow } = vi.hoisted(() => ({
+  mockKillTmuxWindow: vi.fn(),
+}))
+
+vi.mock('../../src/spawner/tmux.js', () => ({
+  killTmuxWindow: mockKillTmuxWindow,
+  captureTmuxPane: vi.fn(() => ''),
+  spawnTmuxWorker: vi.fn(),
+  ensureTmuxSession: vi.fn(() => 'multiclaude'),
+  createTmuxWindow: vi.fn(() => '@1'),
+  getTmuxPanePid: vi.fn(() => undefined),
+  sendTmuxKeys: vi.fn(),
+  writeLaunchScript: vi.fn(() => '/tmp/worker-launch.sh'),
+  sendToPane: vi.fn(() => ({ sent: true, enterRetries: 0 })),
+  capturePaneText: vi.fn(() => ''),
+  classifyComposerState: vi.fn(() => 'empty'),
+  isPaneBusy: vi.fn(() => false),
+}))
+
+import { createDb, closeDb } from '../../src/server/state/db.js'
+import { createTask, updateTask } from '../../src/server/state/tasks.js'
+import { registerAgent, updateAgent } from '../../src/server/state/agents.js'
+import { handleReportDone } from '../../src/server/tools/worker.js'
+import { handleCancelTask } from '../../src/server/tools/orchestrator.js'
+import { checkStuckWorkers } from '../../src/spawner/stuck-watcher.js'
+import type Database from 'better-sqlite3'
+
+function minutesAgo(minutes: number): string {
+  return new Date(Date.now() - minutes * 60_000).toISOString()
+}
+
+describe('tmux window reaping on terminal states', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = createDb(':memory:')
+    mockKillTmuxWindow.mockReset()
+  })
+
+  afterEach(() => {
+    closeDb(db)
+  })
+
+  describe('report_done', () => {
+    it('kills the tmux window when task completes successfully', async () => {
+      createTask(db, { id: 't1', title: 'Test task' })
+      updateTask(db, 't1', { status: 'in_progress', agent_id: 'w-t1' })
+      registerAgent(db, { id: 'w-t1', task_id: 't1' })
+      updateAgent(db, 'w-t1', { tmux_pane: '@42' })
+
+      await handleReportDone(db, 't1', 'Done')
+
+      expect(mockKillTmuxWindow).toHaveBeenCalledWith('@42')
+    })
+
+    it('does not call killTmuxWindow when agent has no tmux_pane', async () => {
+      createTask(db, { id: 't1', title: 'Test task' })
+      updateTask(db, 't1', { status: 'in_progress', agent_id: 'w-t1' })
+      registerAgent(db, { id: 'w-t1', task_id: 't1' })
+      // No tmux_pane set
+
+      await handleReportDone(db, 't1', 'Done')
+
+      expect(mockKillTmuxWindow).not.toHaveBeenCalled()
+    })
+
+    it('does not call killTmuxWindow when task has no agent_id', async () => {
+      createTask(db, { id: 't1', title: 'Test task' })
+      updateTask(db, 't1', { status: 'in_progress' })
+
+      await handleReportDone(db, 't1', 'Done')
+
+      expect(mockKillTmuxWindow).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('cancel_task', () => {
+    it('kills the tmux window when task is cancelled and agent has a pane', () => {
+      createTask(db, { id: 't1', title: 'Test task' })
+      updateTask(db, 't1', { status: 'in_progress', agent_id: 'w-t1' })
+      registerAgent(db, { id: 'w-t1', task_id: 't1' })
+      updateAgent(db, 'w-t1', { tmux_pane: '@7' })
+
+      handleCancelTask(db, 't1')
+
+      expect(mockKillTmuxWindow).toHaveBeenCalledWith('@7')
+    })
+
+    it('does not call killTmuxWindow when task has no agent', () => {
+      createTask(db, { id: 't1', title: 'Test task' })
+
+      handleCancelTask(db, 't1')
+
+      expect(mockKillTmuxWindow).not.toHaveBeenCalled()
+    })
+
+    it('does not call killTmuxWindow when agent has no tmux_pane', () => {
+      createTask(db, { id: 't1', title: 'Test task' })
+      updateTask(db, 't1', { status: 'in_progress', agent_id: 'w-t1' })
+      registerAgent(db, { id: 'w-t1', task_id: 't1' })
+
+      handleCancelTask(db, 't1')
+
+      expect(mockKillTmuxWindow).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('stuck-watcher timeout', () => {
+    it('kills the tmux window when a task times out', () => {
+      db.prepare(
+        "INSERT INTO tasks (id, title, status, started_at) VALUES ('t1', 'T', 'in_progress', ?)"
+      ).run(minutesAgo(15))
+      db.prepare("INSERT INTO agents (id, task_id, status, tmux_pane) VALUES ('a1', 't1', 'running', '@99')").run()
+      db.prepare(
+        "INSERT INTO logs (task_id, level, message, created_at) VALUES ('t1', 'info', 'old', ?)"
+      ).run(minutesAgo(15))
+
+      const stuckSince = new Map<string, number>()
+      const mockCapture = () => 'idle'
+      checkStuckWorkers(db, stuckSince, 5, 10, Date.now(), mockCapture, mockKillTmuxWindow)
+
+      expect(mockKillTmuxWindow).toHaveBeenCalledWith('@99')
+    })
+  })
+})


### PR DESCRIPTION
Fixes six open issues and partially addresses a seventh, covering worker isolation, false-completion reporting, spawn reliability, and PR hygiene.

## Tasks included

- **worktree-commit-isolation** (#96): Enforce the worktree boundary in `src/git/worktree.ts` and `src/spawner/index.ts` so worker commits cannot land on the parent repo's checked-out branch. Isolation is now a process constraint rather than prompt guidance.
- **empty-branch-detection** (#96): Detect task branches with zero commits at `report_done` and fail with a distinguishable reason instead of merging them as a silent no-op.
- **merge-verification** (#95, partial): `report_done` now confirms the task branch is an ancestor of the run branch via `git merge-base --is-ancestor` and refuses `done` otherwise. Aborted/conflicted merges mark the task `failed` rather than passing silently.
- **effort-canonicalize** (#94): One canonical effort set — `low|medium|high|xhigh|max` — across `plan_dag`, `CLAUDE.md`, and `prompts/orchestrator.md`. `extra` is accepted as an alias and normalised to `xhigh` at plan time, so the stored record reflects what actually runs. Invalid values are rejected with a clear error instead of being silently downgraded.
- **agent-process-verification** (#93): Verify a `claude` process actually started before writing `in_progress`; record the agent pid rather than the wrapper shell's; add a first-activity heartbeat so "registered" is distinguishable from "working".
- **tmux-window-lifecycle** (#92): Window names are unique per attempt, targeting is by tmux window ID (`@NN`) captured at creation, and windows are reaped on terminal states. Retries can no longer resolve to a prior attempt's dead window.
- **merge-conflict-reduction** (#48): Bring each task branch up to date with the run branch before merging, serialize merges into the integration branch, and extend mechanical-conflict auto-resolution. Unresolvable conflicts fail loudly with the conflicting paths named.

## Why #95 is not closed by this PR

#95 has four acceptance criteria. Three are met above. The fourth — "orchestrator can verify merge status without inspecting diffs", i.e. exposing `merged_into_run` through `get_system_status` — is **not** in this PR. Its worker failed to spawn four times: worktree and tmux window creation returns `pid: null, tmux_pane: null` immediately, while all eight other tasks in this run spawned normally. Both the remaining field and that spawn failure are filed as follow-up issues.

Closes #96, closes #94, closes #93, closes #92, closes #89, closes #48

Refs #95
