### PR TITLE
Self-healing runs: server-side remediation before escalating to the user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 dist/
 *.db
 *.db-shm

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,11 +382,21 @@ Workers take time — **patience is required.** A worker that hasn't reported pr
 
 ## Failure Handling
 
-The spawner watcher **automatically retries** failed tasks up to `max_retries` times — you don't need to manually re-spawn. Only act when a task's `retry_count >= max_retries` (all retries exhausted):
+When a task fails, attempt recovery before escalating. The recovery-first policy:
 
-1. Check `logs` in the status output for error context
-2. If the failure needs user input or a code fix: escalate with a brief summary of the error — don't dump the full log
-3. If the worker completed the work but failed to call `report_done` (rare): call `complete_task(task_id, summary)` as a manual override
+**Recovery phase:**
+1. Task fails → call `recover_task(task_id)` immediately with the failure context
+2. Check the `verdict`:
+   - **`recovered`**: Task was repaired automatically. Re-spawn it and continue without user involvement. Report as one line: `"✓ task-id recovered and re-spawned."`
+   - **`unrecoverable` or `needs_human`**: Only escalate (see below)
+   - **`needs_retry`** but `retry_count >= max_retries`: Escalate (retries genuinely exhausted)
+
+**Escalation phase** (only when recovery verdict isn't `recovered`):
+1. State what recovery already attempted and what was found
+2. Be specific about the decision needed — not a list of shell commands or logs for the user to debug
+3. The orchestrator must not run shell commands; recovery is handled server-side by `recover_task` and the coordination server
+
+Example escalation: *"Task X failed with [specific error]. Recovery attempted [strategies tried]. Root cause: [what was found]. Need user input: [specific decision]."*
 
 ---
 
@@ -401,6 +411,7 @@ The spawner watcher **automatically retries** failed tasks up to `max_retries` t
 | `wait_for_event(timeout_seconds?, include_done?)` | **Monitoring loop** — blocks until something changes, then returns active tasks by default; always includes active_count and done_count |
 | `spawn_worker(task_id, agent_id, cwd)` | For every ready task, and after deps complete |
 | `cancel_task(task_id)` | When user wants to abort a task |
+| `recover_task(task_id)` | When a task fails — attempts automatic recovery; returns verdict (`recovered`, `unrecoverable`, `needs_human`, or `needs_retry`) |
 | `complete_task(task_id, summary)` | Recovery only — when worker did work but died without reporting |
 | `list_projects()` | List all projects with aggregate stats (task counts, run count, last_active_at) |
 | `list_runs(project_id?)` | List runs (optionally filtered by project); each shows task counts and derived_status |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,7 +389,7 @@ When a task fails, attempt recovery before escalating. The recovery-first policy
 2. Check the `verdict`:
    - **`recovered`**: Task was repaired automatically. Re-spawn it and continue without user involvement. Report as one line: `"✓ task-id recovered and re-spawned."`
    - **`unrecoverable` or `needs_human`**: Only escalate (see below)
-   - **`needs_retry`** but `retry_count >= max_retries`: Escalate (retries genuinely exhausted)
+   - Independently of the verdict: if `retry_count >= max_retries`, stop re-spawning and escalate — retries are genuinely exhausted
 
 **Escalation phase** (only when recovery verdict isn't `recovered`):
 1. State what recovery already attempted and what was found
@@ -411,7 +411,7 @@ Example escalation: *"Task X failed with [specific error]. Recovery attempted [s
 | `wait_for_event(timeout_seconds?, include_done?)` | **Monitoring loop** — blocks until something changes, then returns active tasks by default; always includes active_count and done_count |
 | `spawn_worker(task_id, agent_id, cwd)` | For every ready task, and after deps complete |
 | `cancel_task(task_id)` | When user wants to abort a task |
-| `recover_task(task_id)` | When a task fails — attempts automatic recovery; returns verdict (`recovered`, `unrecoverable`, `needs_human`, or `needs_retry`) |
+| `recover_task(task_id)` | When a task fails — attempts automatic recovery; returns verdict (`recovered`, `unrecoverable`, or `needs_human`) |
 | `complete_task(task_id, summary)` | Recovery only — when worker did work but died without reporting |
 | `list_projects()` | List all projects with aggregate stats (task counts, run count, last_active_at) |
 | `list_runs(project_id?)` | List runs (optionally filtered by project); each shows task counts and derived_status |

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/marcus/Developer/MultiClaude/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/marcus/Developer/MultiClaude/node_modules

--- a/prompts/orchestrator.md
+++ b/prompts/orchestrator.md
@@ -253,7 +253,7 @@ When a task fails, attempt recovery before escalating. The recovery-first policy
 2. Check the `verdict`:
    - **`recovered`**: Task was repaired automatically. Re-spawn it and continue without user involvement. Report as one line: `"✓ task-id recovered and re-spawned."`
    - **`unrecoverable` or `needs_human`**: Only escalate (see below)
-   - **`needs_retry`** but `retry_count >= max_retries`: Escalate (retries genuinely exhausted)
+   - Independently of the verdict: if `retry_count >= max_retries`, stop re-spawning and escalate — retries are genuinely exhausted
 
 **Escalation phase** (only when recovery verdict isn't `recovered`):
 1. State what recovery already attempted and what was found
@@ -275,7 +275,7 @@ Example escalation: *"Task X failed with [specific error]. Recovery attempted [s
 | `wait_for_event(timeout_seconds?, include_done?)` | **Monitoring loop** — blocks until something changes, then returns active tasks by default; always includes active_count and done_count |
 | `spawn_worker(task_id, agent_id, cwd)` | For every ready task, and after deps complete |
 | `cancel_task(task_id)` | When user wants to abort a task |
-| `recover_task(task_id)` | When a task fails — attempts automatic recovery; returns verdict (`recovered`, `unrecoverable`, `needs_human`, or `needs_retry`) |
+| `recover_task(task_id)` | When a task fails — attempts automatic recovery; returns verdict (`recovered`, `unrecoverable`, or `needs_human`) |
 | `complete_task(task_id, summary)` | Recovery only — when worker did work but died without reporting |
 | `list_projects()` | List all projects with aggregate stats (task counts, run count, last_active_at) |
 | `list_runs(project_id?)` | List runs (optionally filtered by project); each shows task counts and derived_status |

--- a/prompts/orchestrator.md
+++ b/prompts/orchestrator.md
@@ -246,11 +246,21 @@ Workers take time — **patience is required.** A worker that hasn't reported pr
 
 ## Failure Handling
 
-The spawner watcher **automatically retries** failed tasks up to `max_retries` times — you don't need to manually re-spawn. Only act when a task's `retry_count >= max_retries` (all retries exhausted):
+When a task fails, attempt recovery before escalating. The recovery-first policy:
 
-1. Check `logs` in the status output for error context
-2. If the failure needs user input or a code fix: escalate with a brief summary of the error — don't dump the full log
-3. If the worker completed the work but failed to call `report_done` (rare): call `complete_task(task_id, summary)` as a manual override
+**Recovery phase:**
+1. Task fails → call `recover_task(task_id)` immediately with the failure context
+2. Check the `verdict`:
+   - **`recovered`**: Task was repaired automatically. Re-spawn it and continue without user involvement. Report as one line: `"✓ task-id recovered and re-spawned."`
+   - **`unrecoverable` or `needs_human`**: Only escalate (see below)
+   - **`needs_retry`** but `retry_count >= max_retries`: Escalate (retries genuinely exhausted)
+
+**Escalation phase** (only when recovery verdict isn't `recovered`):
+1. State what recovery already attempted and what was found
+2. Be specific about the decision needed — not a list of shell commands or logs for the user to debug
+3. The orchestrator must not run shell commands; recovery is handled server-side by `recover_task` and the coordination server
+
+Example escalation: *"Task X failed with [specific error]. Recovery attempted [strategies tried]. Root cause: [what was found]. Need user input: [specific decision]."*
 
 ---
 
@@ -265,6 +275,7 @@ The spawner watcher **automatically retries** failed tasks up to `max_retries` t
 | `wait_for_event(timeout_seconds?, include_done?)` | **Monitoring loop** — blocks until something changes, then returns active tasks by default; always includes active_count and done_count |
 | `spawn_worker(task_id, agent_id, cwd)` | For every ready task, and after deps complete |
 | `cancel_task(task_id)` | When user wants to abort a task |
+| `recover_task(task_id)` | When a task fails — attempts automatic recovery; returns verdict (`recovered`, `unrecoverable`, `needs_human`, or `needs_retry`) |
 | `complete_task(task_id, summary)` | Recovery only — when worker did work but died without reporting |
 | `list_projects()` | List all projects with aggregate stats (task counts, run count, last_active_at) |
 | `list_runs(project_id?)` | List runs (optionally filtered by project); each shows task counts and derived_status |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import { getTask, updateTask, listTasks } from './server/state/tasks.js'
 import { updateAgent } from './server/state/agents.js'
 import { handleSpawnWorker } from './server/tools/orchestrator.js'
 import { checkStuckWorkers, AGENT_NEVER_STARTED_REASON } from './spawner/stuck-watcher.js'
-import { killTmuxWindow, getChildProcessPid, reapOrphanWindows } from './spawner/tmux.js'
+import { killTmuxWindow, getChildProcessPid } from './spawner/tmux.js'
 import { writeFileSync, readFileSync, mkdirSync, rmSync, existsSync } from 'fs'
 import { join } from 'path'
 import { execSync } from 'child_process'
@@ -298,13 +298,9 @@ function startSpawnerWatcher(
 
   // Stuck worker detection — runs every 60 seconds.
   // Warns at stuckWarningMinutes, times out at stuckTimeoutMinutes.
-  // Also reaps orphaned tmux windows for tasks already in terminal states.
   const stuckSince = new Map<string, number>()
   setInterval(() => {
     checkStuckWorkers(db, stuckSince, stuckWarningMinutes, stuckTimeoutMinutes)
-    if (effectiveRuntime === 'tmux') {
-      reapOrphanWindows(db)
-    }
   }, 60_000)
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import { getTask, updateTask, listTasks } from './server/state/tasks.js'
 import { updateAgent } from './server/state/agents.js'
 import { handleSpawnWorker } from './server/tools/orchestrator.js'
 import { checkStuckWorkers, AGENT_NEVER_STARTED_REASON } from './spawner/stuck-watcher.js'
-import { killTmuxWindow, getChildProcessPid } from './spawner/tmux.js'
+import { killTmuxWindow, getChildProcessPid, reapOrphanWindows } from './spawner/tmux.js'
 import { writeFileSync, readFileSync, mkdirSync, rmSync, existsSync } from 'fs'
 import { join } from 'path'
 import { execSync } from 'child_process'
@@ -162,6 +162,7 @@ function startSpawnerWatcher(
         const msg = err instanceof Error ? err.message : String(err)
         console.error(`[spawner] Failed to launch worker ${agent.id}: ${msg}`)
         updateAgent(db, agent.id, { status: 'failed' })
+        updateTask(db, task.id, { status: 'failed', failure_reason: msg })
         continue
       }
 
@@ -278,9 +279,13 @@ function startSpawnerWatcher(
 
   // Stuck worker detection — runs every 60 seconds.
   // Warns at stuckWarningMinutes, times out at stuckTimeoutMinutes.
+  // Also reaps orphaned tmux windows for tasks already in terminal states.
   const stuckSince = new Map<string, number>()
   setInterval(() => {
     checkStuckWorkers(db, stuckSince, stuckWarningMinutes, stuckTimeoutMinutes)
+    if (effectiveRuntime === 'tmux') {
+      reapOrphanWindows(db)
+    }
   }, 60_000)
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,8 @@ import type { RuntimeBackend } from './spawner/backend.js'
 import { openWorkerTerminal } from './spawner/terminal.js'
 import { getTask, updateTask, listTasks } from './server/state/tasks.js'
 import { updateAgent } from './server/state/agents.js'
-import { handleSpawnWorker } from './server/tools/orchestrator.js'
+import { handleSpawnWorker, handleRecoverTask } from './server/tools/orchestrator.js'
+import { shouldAttemptRecovery, applyRecoveryOutcome, MAX_RECOVERY_ATTEMPTS } from './spawner/auto-recovery.js'
 import { checkStuckWorkers, AGENT_NEVER_STARTED_REASON } from './spawner/stuck-watcher.js'
 import { killTmuxWindow, getChildProcessPid, reapOrphanWindows } from './spawner/tmux.js'
 import { writeFileSync, readFileSync, mkdirSync, rmSync, existsSync } from 'fs'
@@ -75,15 +76,17 @@ function startSpawnerWatcher(
 ): void {
   const launched = new Set<string>()
   const retried = new Set<string>()  // tracks "{taskId}-{retryAttempt}" to avoid double-spawning
+  const recovering = new Set<string>()  // tasks currently undergoing async auto-recovery
 
   setInterval(() => {
     // Auto-retry failed tasks that still have remaining retries
     const failedTasks = listTasks(db, 'failed').filter(t => t.retry_count < t.max_retries)
     for (const task of failedTasks) {
+      if (recovering.has(task.id)) continue  // async recovery already in flight
+
       const retryAttempt = task.retry_count + 1
       const retryKey = `${task.id}-${retryAttempt}`
       if (retried.has(retryKey)) continue
-      retried.add(retryKey)
 
       // Find cwd from the most recent agent for this task, or fall back to repo_path
       // (repo_path is saved early in handleSpawnWorker before worktree creation, so it
@@ -97,6 +100,62 @@ function startSpawnerWatcher(
         console.warn(`[spawner] Cannot retry task ${task.id}: no cwd found for previous agent`)
         continue
       }
+
+      // --- Auto-recovery: attempt environment repair BEFORE consuming a retry slot ---
+      // Only runs when there is a machine-readable failure_reason (environment issue).
+
+      if (task.failure_reason) {
+        if (shouldAttemptRecovery(task)) {
+          // Mark as in-flight to prevent duplicate recovery in the next tick.
+          recovering.add(task.id)
+          retried.add(retryKey)
+
+          console.log(
+            `[spawner] Auto-recovering task ${task.id} (recovery attempt ${task.recovery_attempts + 1}/${MAX_RECOVERY_ATTEMPTS}, failure: ${task.failure_reason})`
+          )
+
+          void handleRecoverTask(db, task.id).then(result => {
+            recovering.delete(task.id)
+            const outcome = applyRecoveryOutcome(db, task, result)
+
+            if (outcome === 'respawn') {
+              // Recovery repaired the environment — re-spawn without consuming a retry slot.
+              const recoveryAgentId = `w-${task.id}-r${task.recovery_attempts + 1}`
+              void handleSpawnWorker(db, task.id, recoveryAgentId, { cwd: retryCwd }).then(spawnResult => {
+                if (!spawnResult.ok) {
+                  console.error(`[spawner] Failed to respawn after recovery for task ${task.id}: ${spawnResult.error}`)
+                  updateTask(db, task.id, { status: 'failed' })
+                }
+                // Remove the key so a subsequent failure gets a fresh recovery attempt.
+                retried.delete(retryKey)
+              })
+            } else {
+              // Needs human or unrecoverable — task already exhausted in applyRecoveryOutcome.
+              console.warn(`[spawner] Task ${task.id} recovery verdict: ${result.verdict} — ${result.reason ?? 'no details'}`)
+              retried.delete(retryKey)
+            }
+          })
+          continue
+        }
+
+        // Recovery cap reached — fail permanently without consuming a retry slot.
+        retried.add(retryKey)
+        console.warn(`[spawner] Task ${task.id} hit recovery cap (${MAX_RECOVERY_ATTEMPTS}) — escalating`)
+        db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
+          task.id, 'error',
+          `Recovery cap (${MAX_RECOVERY_ATTEMPTS}) reached — manual intervention required`
+        )
+        updateTask(db, task.id, {
+          status: 'failed',
+          retry_count: task.max_retries,
+          failure_reason: 'recovery_cap_reached',
+          failure_detail: `Auto-recovery attempted ${MAX_RECOVERY_ATTEMPTS} times without success`,
+        })
+        continue
+      }
+
+      // --- Normal retry (no machine-readable failure_reason) ---
+      retried.add(retryKey)
 
       // Get failure reason from the most recent error/warn log entry (skip info-level
       // "Retry attempt" messages so the reason doesn't nest recursively on each retry)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import { getTask, updateTask, listTasks } from './server/state/tasks.js'
 import { updateAgent } from './server/state/agents.js'
 import { handleSpawnWorker } from './server/tools/orchestrator.js'
 import { checkStuckWorkers, AGENT_NEVER_STARTED_REASON } from './spawner/stuck-watcher.js'
-import { killTmuxWindow, getChildProcessPid } from './spawner/tmux.js'
+import { killTmuxWindow, getChildProcessPid, reapOrphanWindows } from './spawner/tmux.js'
 import { writeFileSync, readFileSync, mkdirSync, rmSync, existsSync } from 'fs'
 import { join } from 'path'
 import { execSync } from 'child_process'
@@ -298,9 +298,13 @@ function startSpawnerWatcher(
 
   // Stuck worker detection — runs every 60 seconds.
   // Warns at stuckWarningMinutes, times out at stuckTimeoutMinutes.
+  // Also reaps orphaned tmux windows for tasks already in terminal states.
   const stuckSince = new Map<string, number>()
   setInterval(() => {
     checkStuckWorkers(db, stuckSince, stuckWarningMinutes, stuckTimeoutMinutes)
+    if (effectiveRuntime === 'tmux') {
+      reapOrphanWindows(db)
+    }
   }, 60_000)
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@
 import { startCoordServer } from './server/index.js'
 import { startWebServer } from './web/server.js'
 import { startTui } from './tui/index.js'
-import { writeWorkerMcpConfig, workerLogPath } from './spawner/index.js'
+import { writeWorkerMcpConfig, workerLogPath, classifyLaunchError } from './spawner/index.js'
 import { createBackend } from './spawner/backend.js'
 import type { RuntimeBackend } from './spawner/backend.js'
 import { openWorkerTerminal } from './spawner/terminal.js'
@@ -85,12 +85,15 @@ function startSpawnerWatcher(
       if (retried.has(retryKey)) continue
       retried.add(retryKey)
 
-      // Find cwd from the most recent agent for this task
+      // Find cwd from the most recent agent for this task, or fall back to repo_path
+      // (repo_path is saved early in handleSpawnWorker before worktree creation, so it
+      // exists even when the agent was never registered due to a worktree creation failure).
       const prevAgent = db.prepare(
         "SELECT * FROM agents WHERE task_id = ? ORDER BY created_at DESC LIMIT 1"
       ).get(task.id) as AgentRow | undefined
 
-      if (!prevAgent?.cwd) {
+      const retryCwd = prevAgent?.cwd ?? task.repo_path ?? null
+      if (!retryCwd) {
         console.warn(`[spawner] Cannot retry task ${task.id}: no cwd found for previous agent`)
         continue
       }
@@ -114,11 +117,13 @@ function startSpawnerWatcher(
       )
 
       // Register new agent and transition task to in_progress
-      void handleSpawnWorker(db, task.id, newAgentId, { cwd: prevAgent.cwd }).then(result => {
+      void handleSpawnWorker(db, task.id, newAgentId, { cwd: retryCwd }).then(result => {
         if (!result.ok) {
           console.error(`[spawner] Failed to register retry worker for task ${task.id}: ${result.error}`)
-          // Revert so we can retry again on the next tick
-          updateTask(db, task.id, { retry_count: task.retry_count, status: 'failed' })
+          // Keep retry_count at retryAttempt (already written) so the next retry key
+          // advances. Reverting to task.retry_count caused infinite loops because the
+          // retried set was cleared while retry_count stayed at 0.
+          updateTask(db, task.id, { status: 'failed' })
           retried.delete(retryKey)
         }
       })
@@ -161,8 +166,17 @@ function startSpawnerWatcher(
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err)
         console.error(`[spawner] Failed to launch worker ${agent.id}: ${msg}`)
-        updateAgent(db, agent.id, { status: 'failed' })
-        updateTask(db, task.id, { status: 'failed', failure_reason: msg })
+        const failureReason = classifyLaunchError(msg)
+        updateAgent(db, agent.id, { status: 'failed', failure_reason: failureReason, failure_detail: msg })
+        if (agent.task_id) {
+          const t = getTask(db, agent.task_id)
+          if (t && t.status !== 'done') {
+            updateTask(db, agent.task_id, { status: 'failed', failure_reason: failureReason, failure_detail: msg })
+          }
+          db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
+            agent.task_id, 'error', `${failureReason}: ${msg}`
+          )
+        }
         continue
       }
 
@@ -233,13 +247,18 @@ function startSpawnerWatcher(
       }
 
       handle.onError((err) => {
-        console.error(`[spawner] Failed to launch worker ${agent.id}: ${err.message}`)
-        updateAgent(db, agent.id, { status: 'failed' })
+        const msg = err.message
+        console.error(`[spawner] Failed to launch worker ${agent.id}: ${msg}`)
+        const failureReason = classifyLaunchError(msg)
+        updateAgent(db, agent.id, { status: 'failed', failure_reason: failureReason, failure_detail: msg })
         if (agent.task_id) {
           const t = getTask(db, agent.task_id)
           if (t && t.status !== 'done') {
-            updateTask(db, agent.task_id, { status: 'failed' })
+            updateTask(db, agent.task_id, { status: 'failed', failure_reason: failureReason, failure_detail: msg })
           }
+          db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
+            agent.task_id, 'error', `${failureReason}: ${msg}`
+          )
         }
       })
 

--- a/src/git/merge.ts
+++ b/src/git/merge.ts
@@ -81,6 +81,36 @@ async function isAncestorOf(
   }
 }
 
+/**
+ * Check whether a task branch has been merged into the integration branch.
+ * Robust to deleted local task branches: tries the local ref first, then
+ * origin/<taskBranch> as a fallback, so it succeeds even when cleanup has
+ * already removed the local branch. Returns false (never throws) when neither
+ * ref resolves — that is the conservative safe default.
+ */
+export async function isMergedInto(
+  repoPath: string,
+  taskBranch: string,
+  integBranch: string,
+): Promise<boolean> {
+  const git = simpleGit(repoPath)
+  const candidates = [taskBranch, `origin/${taskBranch}`]
+
+  for (const ref of candidates) {
+    try {
+      const ancestorSha = (await git.revparse([ref])).trim()
+      const descendantSha = (await git.revparse([integBranch])).trim()
+      if (ancestorSha === descendantSha) return true
+      const mergeBase = (await git.raw(['merge-base', ancestorSha, descendantSha])).trim()
+      if (mergeBase === ancestorSha) return true
+    } catch {
+      // ref doesn't exist or merge-base failed; try next candidate
+    }
+  }
+
+  return false
+}
+
 export async function ensureIntegrationBranch(repoPath: string, runId?: string): Promise<void> {
   const git = simpleGit(repoPath)
   const branch = getIntegBranch(runId)

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -218,10 +218,51 @@ async function allocateSuffixedBranch(
   throw new Error(`Could not allocate suffixed branch name for ${branch} after 100 attempts`)
 }
 
+/**
+ * Removes any stray `core.worktree` from the parent repository's shared git
+ * config. Workers receive GIT_DIR/GIT_WORK_TREE env vars for isolation, but
+ * if anything writes `core.worktree` to the shared .git/config, the parent
+ * repo breaks when the temp worktree directory is deleted.
+ */
+export async function sanitizeParentGitConfig(repoPath: string): Promise<void> {
+  const git = simpleGit(repoPath)
+  try {
+    const value = (await git.raw(['config', '--local', '--get', 'core.worktree'])).trim()
+    if (value) {
+      await git.raw(['config', '--local', '--unset', 'core.worktree'])
+    }
+  } catch {
+    // exit code 1 = key not found — the expected state
+  }
+}
+
+/**
+ * Asserts that the parent repository's shared git config does not contain
+ * `core.worktree`. Throws if it does — this key should never be in the
+ * shared config when using the worktree isolation model.
+ */
+export async function assertSharedConfigClean(repoPath: string): Promise<void> {
+  const git = simpleGit(repoPath)
+  let value: string | undefined
+  try {
+    value = (await git.raw(['config', '--local', '--get', 'core.worktree'])).trim()
+  } catch {
+    return
+  }
+  if (value) {
+    throw new Error(
+      `Shared git config at ${repoPath} contains core.worktree=${value}. ` +
+      `This corrupts the repository when the worktree is deleted. ` +
+      `Use environment variables (GIT_DIR, GIT_WORK_TREE) for isolation instead.`
+    )
+  }
+}
+
 export async function removeWorktree(repoPath: string, info: Pick<WorktreeInfo, 'path' | 'branch'>): Promise<void> {
   const git = simpleGit(repoPath)
   // Silently ignore errors when the worktree is already gone (idempotent)
   await git.raw(['worktree', 'remove', '--force', info.path]).catch(() => {})
   await git.raw(['branch', '-D', info.branch]).catch(() => {})
   await rm(info.path, { recursive: true, force: true }).catch(() => {})
+  await sanitizeParentGitConfig(repoPath).catch(() => {})
 }

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -4,15 +4,29 @@ import { rm } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join, isAbsolute, resolve } from 'path'
 
+export interface ReconcileAction {
+  type: 'prune' | 'remove-worktree' | 'delete-branch' | 'allocate-suffix'
+  target: string
+  detail: string
+}
+
 export interface WorktreeInfo {
   path: string
   branch: string
   taskId: string
   gitDir: string
   headSha: string
+  reconcileActions: ReconcileAction[]
+  priorBranch?: string
 }
 
 const STOP_WORDS = new Set(['a', 'an', 'the', 'and', 'or', 'in', 'on', 'at', 'to', 'for', 'of', 'with', 'use', 'using'])
+
+const PROTECTED_BRANCH_RE = /^(main|master)$|^mc\/run-/
+
+export function isProtectedBranch(branch: string): boolean {
+  return PROTECTED_BRANCH_RE.test(branch)
+}
 
 /**
  * Derive a git branch name from a task title.
@@ -62,19 +76,103 @@ export function readWorktreeGitDir(worktreePath: string): string {
   return isAbsolute(gitDir) ? gitDir : resolve(worktreePath, gitDir)
 }
 
+export async function preflightReconcile(
+  git: ReturnType<typeof simpleGit>,
+  branch: string,
+  baseBranch?: string,
+): Promise<{ actions: ReconcileAction[]; branch: string; priorBranch?: string }> {
+  const actions: ReconcileAction[] = []
+
+  if (isProtectedBranch(branch)) {
+    throw new Error(`Refusing to reconcile protected branch: ${branch}`)
+  }
+
+  const currentBranch = (await git.raw(['branch', '--show-current']).catch(() => '')).trim()
+  if (currentBranch && branch === currentBranch) {
+    throw new Error(`Refusing to reconcile the repository's checked-out branch: ${branch}`)
+  }
+
+  // Step 1: Prune stale worktrees and check if branch exists
+  await git.raw(['worktree', 'prune'])
+
+  const branchExists = (await git.raw(['branch', '--list', branch]).catch(() => '')).trim()
+  if (!branchExists) {
+    return { actions, branch }
+  }
+
+  // Branch exists — full reconcile: check worktree state before and after prune
+  const worktreeList = await git.raw(['worktree', 'list', '--porcelain'])
+
+  // Step 2: If a worktree is still registered for this branch, remove it when clean
+  const existingPath = parseWorktreePathForBranch(worktreeList, branch)
+  if (existingPath) {
+    let removed = false
+    try {
+      const wtGit = simpleGit(existingPath)
+      const status = await wtGit.status()
+      if (status.isClean()) {
+        await git.raw(['worktree', 'remove', existingPath])
+        await rm(existingPath, { recursive: true, force: true }).catch(() => {})
+        actions.push({ type: 'remove-worktree', target: existingPath, detail: `Removed clean worktree at ${existingPath}` })
+        removed = true
+      }
+    } catch {
+      // Directory inaccessible or corrupt — force remove the entry
+      await git.raw(['worktree', 'remove', '--force', existingPath]).catch(async () => {
+        await git.raw(['worktree', 'prune'])
+      })
+      await rm(existingPath, { recursive: true, force: true }).catch(() => {})
+      actions.push({ type: 'remove-worktree', target: existingPath, detail: `Force-removed inaccessible worktree at ${existingPath}` })
+      removed = true
+    }
+
+    if (!removed) {
+      // Worktree has uncommitted changes — preserve it, allocate new branch
+      const newBranch = await allocateSuffixedBranch(git, branch)
+      actions.push({
+        type: 'allocate-suffix',
+        target: newBranch,
+        detail: `Worktree at ${existingPath} has uncommitted changes; preserved ${branch}, allocated ${newBranch}`,
+      })
+      return { actions, branch: newBranch, priorBranch: branch }
+    }
+  }
+
+  // Step 3: Branch exists but no worktree — check for unique commits vs base
+  const baseRef = baseBranch || 'HEAD'
+  let uniqueCount = 0
+  try {
+    const uniqueLog = (await git.raw(['log', '--oneline', `${baseRef}..${branch}`])).trim()
+    uniqueCount = uniqueLog ? uniqueLog.split('\n').filter(Boolean).length : 0
+  } catch {
+    uniqueCount = -1
+  }
+
+  if (uniqueCount === 0) {
+    await git.raw(['branch', '-D', branch])
+    actions.push({ type: 'delete-branch', target: branch, detail: `Deleted branch ${branch} (no unique commits vs ${baseRef})` })
+  } else {
+    const newBranch = await allocateSuffixedBranch(git, branch)
+    const countMsg = uniqueCount > 0 ? `${uniqueCount} unique commit(s)` : 'could not determine commit count'
+    actions.push({
+      type: 'allocate-suffix',
+      target: newBranch,
+      detail: `Preserved ${branch} (${countMsg}); allocated ${newBranch}`,
+    })
+    return { actions, branch: newBranch, priorBranch: branch }
+  }
+
+  return { actions, branch }
+}
+
 export async function createWorktree(repoPath: string, taskId: string, taskTitle?: string, baseBranch?: string): Promise<WorktreeInfo> {
-  const branch = taskTitle ? branchNameFromTitle(taskTitle, taskId) : `mc/${taskId}`
-  const worktreePath = mkdtempSync(join(tmpdir(), `mc-${taskId}-`))
+  let branch = taskTitle ? branchNameFromTitle(taskTitle, taskId) : `mc/${taskId}`
   const git = simpleGit(repoPath)
 
-  // Clean up stale worktree/branch from a prior failed attempt (idempotent)
-  const worktreeList = await git.raw(['worktree', 'list', '--porcelain'])
-  const staleWorktreePath = parseWorktreePathForBranch(worktreeList, branch)
-  if (staleWorktreePath) {
-    await git.raw(['worktree', 'remove', '--force', staleWorktreePath]).catch(() => {})
-    await rm(staleWorktreePath, { recursive: true, force: true }).catch(() => {})
-  }
-  await git.raw(['branch', '-D', branch]).catch(() => {})
+  const reconcile = await preflightReconcile(git, branch, baseBranch)
+  branch = reconcile.branch
+
+  const worktreePath = mkdtempSync(join(tmpdir(), `mc-${taskId}-`))
 
   if (baseBranch) {
     await git.raw(['worktree', 'add', '-b', branch, worktreePath, baseBranch])
@@ -86,7 +184,15 @@ export async function createWorktree(repoPath: string, taskId: string, taskTitle
   const worktreeGit = simpleGit(worktreePath)
   const headSha = (await worktreeGit.revparse(['HEAD'])).trim()
 
-  return { path: worktreePath, branch, taskId, gitDir, headSha }
+  return {
+    path: worktreePath,
+    branch,
+    taskId,
+    gitDir,
+    headSha,
+    reconcileActions: reconcile.actions,
+    priorBranch: reconcile.priorBranch,
+  }
 }
 
 function parseWorktreePathForBranch(porcelainOutput: string, branch: string): string | null {
@@ -98,6 +204,18 @@ function parseWorktreePathForBranch(porcelainOutput: string, branch: string): st
     }
   }
   return null
+}
+
+async function allocateSuffixedBranch(
+  git: ReturnType<typeof simpleGit>,
+  branch: string,
+): Promise<string> {
+  for (let i = 2; i <= 100; i++) {
+    const candidate = `${branch}-attempt-${i}`
+    const exists = (await git.raw(['branch', '--list', candidate]).catch(() => '')).trim()
+    if (!exists) return candidate
+  }
+  throw new Error(`Could not allocate suffixed branch name for ${branch} after 100 attempts`)
 }
 
 export async function removeWorktree(repoPath: string, info: Pick<WorktreeInfo, 'path' | 'branch'>): Promise<void> {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,7 +2,7 @@ import express from 'express'
 import { createServer } from 'http'
 import { randomUUID } from 'crypto'
 import { createDb } from './state/db.js'
-import { handlePlanDag, handleGetSystemStatus, handleWaitForEvent, handleCancelTask, handleSpawnWorker, handleCompleteTask, handleCreateRun, handleListProjects, handleListRuns } from './tools/orchestrator.js'
+import { handlePlanDag, handleGetSystemStatus, handleWaitForEvent, handleCancelTask, handleSpawnWorker, handleCompleteTask, handleCreateRun, handleListProjects, handleListRuns, handleRecoverTask } from './tools/orchestrator.js'
 import { backfillProjectsFromAgents } from './state/projects.js'
 import { handleGetMyTask, handleReportProgress, handleReportDone, handleReportBlocked } from './tools/worker.js'
 import type Database from 'better-sqlite3'
@@ -178,6 +178,16 @@ function createOrchestratorMcp(db: Database.Database): McpServer {
     async ({ task_id, summary }) => {
       handleCompleteTask(db, task_id, summary)
       return { content: [{ type: 'text' as const, text: `Task ${task_id} marked as done` }] }
+    }
+  )
+
+  server.tool(
+    'recover_task',
+    'Attempt to recover a failed task by cleaning up stale git state, reaping tmux windows, clearing the agent record, and resetting the task to a spawnable state. Returns a structured report with verdict: recovered (safe to re-spawn), unrecoverable (with reason), or needs_human (with the specific action required).',
+    { task_id: z.string() },
+    async ({ task_id }) => {
+      const result = await handleRecoverTask(db, task_id)
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] }
     }
   )
 

--- a/src/server/state/agents.ts
+++ b/src/server/state/agents.ts
@@ -9,6 +9,8 @@ export interface Agent {
   status: AgentStatus
   cwd: string | null
   tmux_pane: string | null
+  failure_reason: string | null
+  failure_detail: string | null
   created_at: string
 }
 
@@ -25,13 +27,15 @@ export function getAgent(db: Database.Database, id: string): Agent | null {
   return (db.prepare('SELECT * FROM agents WHERE id = ?').get(id) as Agent | undefined) ?? null
 }
 
-export function updateAgent(db: Database.Database, id: string, input: { status?: AgentStatus; pid?: number; cwd?: string; tmux_pane?: string }): void {
+export function updateAgent(db: Database.Database, id: string, input: { status?: AgentStatus; pid?: number; cwd?: string; tmux_pane?: string; failure_reason?: string; failure_detail?: string }): void {
   const sets: string[] = []
   const params: Record<string, unknown> = { id }
   if (input.status !== undefined) { sets.push('status = @status'); params.status = input.status }
   if (input.pid !== undefined) { sets.push('pid = @pid'); params.pid = input.pid }
   if (input.cwd !== undefined) { sets.push('cwd = @cwd'); params.cwd = input.cwd }
   if (input.tmux_pane !== undefined) { sets.push('tmux_pane = @tmux_pane'); params.tmux_pane = input.tmux_pane }
+  if (input.failure_reason !== undefined) { sets.push('failure_reason = @failure_reason'); params.failure_reason = input.failure_reason }
+  if (input.failure_detail !== undefined) { sets.push('failure_detail = @failure_detail'); params.failure_detail = input.failure_detail }
   if (sets.length === 0) return
   db.prepare(`UPDATE agents SET ${sets.join(', ')} WHERE id = @id`).run(params)
 }

--- a/src/server/state/db.ts
+++ b/src/server/state/db.ts
@@ -97,6 +97,7 @@ export function createDb(path: string = './multiclaude.db'): Database.Database {
   try { db.exec("ALTER TABLE tasks ADD COLUMN failure_detail TEXT") } catch { /* already exists */ }
   try { db.exec("ALTER TABLE agents ADD COLUMN failure_reason TEXT") } catch { /* already exists */ }
   try { db.exec("ALTER TABLE agents ADD COLUMN failure_detail TEXT") } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE tasks ADD COLUMN recovery_attempts INTEGER NOT NULL DEFAULT 0") } catch { /* already exists */ }
   return db
 }
 

--- a/src/server/state/db.ts
+++ b/src/server/state/db.ts
@@ -45,6 +45,7 @@ export function createDb(path: string = './multiclaude.db'): Database.Database {
       run_id TEXT REFERENCES runs(id),
       ticket TEXT,
       failure_reason TEXT,
+      failure_detail TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
@@ -61,6 +62,8 @@ export function createDb(path: string = './multiclaude.db'): Database.Database {
       pid INTEGER,
       status TEXT NOT NULL DEFAULT 'spawning',
       cwd TEXT,
+      failure_reason TEXT,
+      failure_detail TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
@@ -91,6 +94,9 @@ export function createDb(path: string = './multiclaude.db'): Database.Database {
   try { db.exec("ALTER TABLE tasks ADD COLUMN ticket TEXT") } catch { /* already exists */ }
   try { db.exec("ALTER TABLE tasks ADD COLUMN head_sha TEXT") } catch { /* already exists */ }
   try { db.exec("ALTER TABLE tasks ADD COLUMN failure_reason TEXT") } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE tasks ADD COLUMN failure_detail TEXT") } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE agents ADD COLUMN failure_reason TEXT") } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE agents ADD COLUMN failure_detail TEXT") } catch { /* already exists */ }
   return db
 }
 

--- a/src/server/state/tasks.ts
+++ b/src/server/state/tasks.ts
@@ -25,6 +25,7 @@ export interface Task {
   run_id: string | null
   ticket: string | null
   failure_reason: string | null
+  failure_detail: string | null
   created_at: string
   updated_at: string
 }
@@ -55,6 +56,7 @@ export interface UpdateTaskInput {
   total_tokens?: number
   cost_usd?: number
   failure_reason?: string
+  failure_detail?: string
 }
 
 export function createTask(db: Database.Database, input: CreateTaskInput): void {
@@ -95,6 +97,7 @@ export function updateTask(db: Database.Database, id: string, input: UpdateTaskI
   if (input.total_tokens !== undefined) { sets.push('total_tokens = @total_tokens'); params.total_tokens = input.total_tokens }
   if (input.cost_usd !== undefined) { sets.push('cost_usd = @cost_usd'); params.cost_usd = input.cost_usd }
   if (input.failure_reason !== undefined) { sets.push('failure_reason = @failure_reason'); params.failure_reason = input.failure_reason }
+  if (input.failure_detail !== undefined) { sets.push('failure_detail = @failure_detail'); params.failure_detail = input.failure_detail }
 
   db.prepare(`UPDATE tasks SET ${sets.join(', ')} WHERE id = @id`).run(params as any)
 }

--- a/src/server/state/tasks.ts
+++ b/src/server/state/tasks.ts
@@ -26,6 +26,7 @@ export interface Task {
   ticket: string | null
   failure_reason: string | null
   failure_detail: string | null
+  recovery_attempts: number
   created_at: string
   updated_at: string
 }
@@ -57,6 +58,7 @@ export interface UpdateTaskInput {
   cost_usd?: number
   failure_reason?: string
   failure_detail?: string
+  recovery_attempts?: number
 }
 
 export function createTask(db: Database.Database, input: CreateTaskInput): void {
@@ -98,6 +100,7 @@ export function updateTask(db: Database.Database, id: string, input: UpdateTaskI
   if (input.cost_usd !== undefined) { sets.push('cost_usd = @cost_usd'); params.cost_usd = input.cost_usd }
   if (input.failure_reason !== undefined) { sets.push('failure_reason = @failure_reason'); params.failure_reason = input.failure_reason }
   if (input.failure_detail !== undefined) { sets.push('failure_detail = @failure_detail'); params.failure_detail = input.failure_detail }
+  if (input.recovery_attempts !== undefined) { sets.push('recovery_attempts = @recovery_attempts'); params.recovery_attempts = input.recovery_attempts }
 
   db.prepare(`UPDATE tasks SET ${sets.join(', ')} WHERE id = @id`).run(params as any)
 }

--- a/src/server/tools/orchestrator.ts
+++ b/src/server/tools/orchestrator.ts
@@ -7,8 +7,8 @@ import { addEdge, getReadyTasks, getBlockers } from '../state/dag.js'
 import { getAgent, listAgents, registerAgent, updateAgent } from '../state/agents.js'
 import { upsertProject, listProjects } from '../state/projects.js'
 import { createRun, getRun, listRunsWithStats, RunWithStats } from '../state/runs.js'
-import { createWorktree } from '../../git/worktree.js'
-import { killTmuxWindow } from '../../spawner/tmux.js'
+import { createWorktree, preflightReconcile, isProtectedBranch } from '../../git/worktree.js'
+import { killTmuxWindow, reapStaleWindows, ensureTmuxSession } from '../../spawner/tmux.js'
 
 export const VALID_EFFORT_VALUES = ['low', 'medium', 'high', 'xhigh', 'max'] as const
 export type EffortValue = typeof VALID_EFFORT_VALUES[number]
@@ -307,4 +307,173 @@ export function classifyWorktreeError(msg: string): string {
   if (/already exists/i.test(msg) && /branch/i.test(msg)) return 'worktree_branch_exists'
   if (/already registered|checked out at/i.test(msg)) return 'worktree_path_registered'
   return 'worktree_create_failed'
+}
+
+export interface RecoverAction {
+  action: string
+  success: boolean
+  detail: string
+}
+
+export type RecoverVerdict = 'recovered' | 'unrecoverable' | 'needs_human'
+
+export interface RecoverResult {
+  task_id: string
+  verdict: RecoverVerdict
+  reason?: string
+  actions: RecoverAction[]
+}
+
+export async function handleRecoverTask(
+  db: Database.Database,
+  taskId: string,
+): Promise<RecoverResult> {
+  const task = getTask(db, taskId)
+  if (!task) {
+    return { task_id: taskId, verdict: 'unrecoverable', reason: 'Task not found', actions: [] }
+  }
+
+  if (task.status === 'done' || task.status === 'cancelled') {
+    return {
+      task_id: taskId,
+      verdict: 'unrecoverable',
+      reason: `Task is already ${task.status}`,
+      actions: [],
+    }
+  }
+
+  if (task.status === 'in_progress') {
+    return {
+      task_id: taskId,
+      verdict: 'needs_human',
+      reason: 'Task is in_progress — cancel it first if recovery is needed',
+      actions: [],
+    }
+  }
+
+  if (task.status === 'pending' && !task.failure_reason && !task.agent_id) {
+    return {
+      task_id: taskId,
+      verdict: 'recovered',
+      reason: 'Task is already in a spawnable state',
+      actions: [],
+    }
+  }
+
+  const actions: RecoverAction[] = []
+  const failureReason = task.failure_reason
+
+  // --- Phase 1: Targeted environment repairs based on failure_reason ---
+
+  if (failureReason?.startsWith('worktree_')) {
+    if (task.repo_path) {
+      const branch = task.branch ?? `mc/${taskId}`
+
+      if (isProtectedBranch(branch)) {
+        return {
+          task_id: taskId,
+          verdict: 'needs_human',
+          reason: `Branch ${branch} is protected — cannot reconcile without risking data loss`,
+          actions,
+        }
+      }
+
+      try {
+        const git = simpleGit(task.repo_path)
+
+        let baseBranch: string | undefined
+        if (task.run_id) {
+          const runBranch = `mc/run-${task.run_id}`
+          const branches = await git.branchLocal()
+          if (branches.all.includes(runBranch)) {
+            baseBranch = runBranch
+          }
+        }
+
+        const reconcile = await preflightReconcile(git, branch, baseBranch)
+        for (const ra of reconcile.actions) {
+          actions.push({ action: `git_reconcile:${ra.type}`, success: true, detail: ra.detail })
+        }
+        if (reconcile.actions.length === 0) {
+          actions.push({ action: 'git_reconcile:noop', success: true, detail: `No git state to clean up for branch ${branch}` })
+        }
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err)
+        if (msg.includes('Refusing to reconcile')) {
+          return { task_id: taskId, verdict: 'needs_human', reason: msg, actions }
+        }
+        actions.push({ action: 'git_reconcile', success: false, detail: `Git reconciliation failed: ${msg}` })
+        return {
+          task_id: taskId,
+          verdict: 'unrecoverable',
+          reason: 'Git reconciliation failed — manual cleanup required',
+          actions,
+        }
+      }
+    } else {
+      actions.push({ action: 'git_reconcile:skip', success: true, detail: 'No repo_path on task — skipping git reconciliation' })
+    }
+  }
+
+  if (failureReason === 'tmux_window_create_failed') {
+    try {
+      const sessionName = ensureTmuxSession()
+      reapStaleWindows(sessionName, taskId)
+      actions.push({ action: 'tmux_reap_stale_windows', success: true, detail: `Reaped stale tmux windows for task ${taskId}` })
+    } catch {
+      actions.push({ action: 'tmux_reap_stale_windows', success: false, detail: 'Tmux unavailable — window reaping skipped (next spawn will retry)' })
+    }
+  }
+
+  if (failureReason === 'tmux_session_create_failed') {
+    actions.push({ action: 'diagnose', success: true, detail: 'Tmux session creation failed — ensure tmux is installed and accessible' })
+  }
+
+  if (failureReason === 'settings_write_failed') {
+    actions.push({ action: 'diagnose', success: true, detail: 'Settings file write failed — check filesystem permissions on the worktree directory' })
+  }
+
+  // --- Phase 2: Clear stale agent record ---
+
+  if (task.agent_id) {
+    const agent = getAgent(db, task.agent_id)
+    if (agent) {
+      if (agent.tmux_pane) {
+        killTmuxWindow(agent.tmux_pane)
+        actions.push({ action: 'kill_agent_tmux_window', success: true, detail: `Killed tmux window ${agent.tmux_pane} for agent ${task.agent_id}` })
+      }
+      if (agent.status !== 'done' && agent.status !== 'failed') {
+        updateAgent(db, task.agent_id, { status: 'failed' })
+        actions.push({ action: 'mark_agent_failed', success: true, detail: `Marked agent ${task.agent_id} as failed` })
+      }
+    }
+  }
+
+  // --- Phase 3: Reset task to spawnable state ---
+
+  db.prepare(`
+    UPDATE tasks SET
+      status = 'pending',
+      agent_id = NULL,
+      failure_reason = NULL,
+      failure_detail = NULL,
+      worktree_path = NULL,
+      branch = NULL,
+      head_sha = NULL,
+      started_at = NULL,
+      updated_at = datetime('now')
+    WHERE id = ?
+  `).run(taskId)
+  actions.push({ action: 'reset_task', success: true, detail: `Reset task ${taskId} to pending state` })
+
+  // --- Phase 4: Verdict ---
+
+  if (failureReason === 'tmux_session_create_failed' || failureReason === 'settings_write_failed') {
+    const envMsg = failureReason === 'tmux_session_create_failed'
+      ? 'Task reset to pending, but tmux session creation previously failed — ensure tmux is available before re-spawning'
+      : 'Task reset to pending, but settings file write previously failed — check filesystem permissions before re-spawning'
+    return { task_id: taskId, verdict: 'needs_human', reason: envMsg, actions }
+  }
+
+  return { task_id: taskId, verdict: 'recovered', actions }
 }

--- a/src/server/tools/orchestrator.ts
+++ b/src/server/tools/orchestrator.ts
@@ -251,6 +251,8 @@ export async function handleSpawnWorker(
   let agentCwd = opts.cwd
   if (opts.cwd) {
     upsertProject(db, { name: path.basename(opts.cwd), cwd: opts.cwd })
+    // Save repo_path before worktree creation so retry loop can find it even if creation fails.
+    updateTask(db, taskId, { repo_path: opts.cwd })
     try {
       let baseBranch: string | undefined
       if (task?.run_id) {
@@ -266,7 +268,8 @@ export async function handleSpawnWorker(
       agentCwd = info.path
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err)
-      updateTask(db, taskId, { status: 'failed' })
+      const failureReason = classifyWorktreeError(msg)
+      updateTask(db, taskId, { status: 'failed', failure_reason: failureReason, failure_detail: msg })
       return { ok: false, error: `Failed to create worktree for task ${taskId}: ${msg}` }
     }
   }
@@ -294,4 +297,14 @@ export function handleListProjects(db: Database.Database) {
 
 export function handleListRuns(db: Database.Database, project_id?: string): RunWithStats[] {
   return listRunsWithStats(db, project_id)
+}
+
+/**
+ * Maps a worktree creation error message to a stable machine-readable slug.
+ * Exported so tests can verify classification without calling handleSpawnWorker.
+ */
+export function classifyWorktreeError(msg: string): string {
+  if (/already exists/i.test(msg) && /branch/i.test(msg)) return 'worktree_branch_exists'
+  if (/already registered|checked out at/i.test(msg)) return 'worktree_path_registered'
+  return 'worktree_create_failed'
 }

--- a/src/server/tools/worker.ts
+++ b/src/server/tools/worker.ts
@@ -3,7 +3,7 @@ import { simpleGit } from 'simple-git'
 import { getTask, updateTask } from '../state/tasks.js'
 import type { Task } from '../state/tasks.js'
 import { getAgent, updateAgent } from '../state/agents.js'
-import { ensureIntegrationBranch, mergeWorktreeBranch, MergeConflictError } from '../../git/merge.js'
+import { ensureIntegrationBranch, mergeWorktreeBranch, MergeConflictError, isMergedInto } from '../../git/merge.js'
 import { removeWorktree } from '../../git/worktree.js'
 import { calculateCost } from '../cost.js'
 import { killTmuxWindow } from '../../spawner/tmux.js'
@@ -77,32 +77,63 @@ export async function handleReportDone(
           // If rev-parse fails (branch gone?), fall through to normal merge which will surface the real error
         }
       }
+      const runId = task.run_id ?? undefined
+      const integBranch = runId ? `mc/run-${runId}` : 'mc/integration'
+
+      // Tightly-scoped merge block — only the merge itself, never cleanup.
+      // Keeping removeWorktree outside ensures a cleanup error cannot be
+      // misattributed as "merge failed" and block downstream DAG tasks.
       try {
-        const runId = task.run_id ?? undefined
         await ensureIntegrationBranch(projectCwd, runId)
         await mergeWorktreeBranch(projectCwd, task.branch, runId, task.worktree_path)
-        const integBranch = runId ? `mc/run-${runId}` : 'mc/integration'
         db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
           taskId, 'info', `Merged and pushed ${task.branch} to origin/${integBranch}`
         )
-        await removeWorktree(projectCwd, { path: task.worktree_path, branch: task.branch })
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err)
-        const failureReason = err instanceof MergeConflictError ? 'merge conflict' : 'merge failed'
-        db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
-          taskId, 'error', `Merge failed: ${task.branch} could not be merged — ${msg}`
-        )
-        // Clean up the worktree so retries can recreate it with the same branch name
-        await removeWorktree(projectCwd, { path: task.worktree_path, branch: task.branch })
-          .catch(() => {}) // best-effort; don't mask the original merge error
-        updateTask(db, taskId, { status: 'failed', failure_reason: failureReason })
-        if (task.agent_id) {
-          updateAgent(db, task.agent_id, { status: 'done' })
-          const agent = getAgent(db, task.agent_id)
-          if (agent?.tmux_pane) killTmuxWindow(agent.tmux_pane)
+
+        // Before marking failed, verify the merge didn't actually land.
+        // Guards against errors thrown inside mergeWorktreeBranch after the
+        // merge commit was made (e.g. push errors) causing false failures.
+        let landed = false
+        try {
+          landed = await isMergedInto(projectCwd, task.branch, integBranch)
+        } catch { /* conservative: assume not landed */ }
+
+        if (landed) {
+          // Merge landed; error came from post-merge code inside mergeWorktreeBranch.
+          // Log it as a non-fatal warning and fall through to mark the task done.
+          db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
+            taskId, 'warn', `post_merge_cleanup_failed: ${msg}`
+          )
+        } else {
+          // Genuine merge failure — mark the task failed.
+          const failureReason = err instanceof MergeConflictError ? 'merge conflict' : 'merge failed'
+          db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
+            taskId, 'error', `Merge failed: ${task.branch} could not be merged — ${msg}`
+          )
+          // Clean up the worktree so retries can recreate it with the same branch name
+          await removeWorktree(projectCwd, { path: task.worktree_path, branch: task.branch })
+            .catch(() => {}) // best-effort; don't mask the original merge error
+          updateTask(db, taskId, { status: 'failed', failure_reason: failureReason })
+          if (task.agent_id) {
+            updateAgent(db, task.agent_id, { status: 'done' })
+            const agent = getAgent(db, task.agent_id)
+            if (agent?.tmux_pane) killTmuxWindow(agent.tmux_pane)
+          }
+          return
         }
-        return
       }
+
+      // Post-merge cleanup — outside the merge try/catch so a cleanup error
+      // never sets failure_reason "merge failed". Non-fatal: log and continue.
+      await removeWorktree(projectCwd, { path: task.worktree_path, branch: task.branch })
+        .catch((cleanupErr: unknown) => {
+          const msg = cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)
+          db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
+            taskId, 'warn', `post_merge_cleanup_failed: ${msg}`
+          )
+        })
     }
   }
   updateTask(db, taskId, {

--- a/src/spawner/auto-recovery.ts
+++ b/src/spawner/auto-recovery.ts
@@ -1,0 +1,56 @@
+import type Database from 'better-sqlite3'
+import type { Task } from '../server/state/tasks.js'
+import type { RecoverResult } from '../server/tools/orchestrator.js'
+import { updateTask } from '../server/state/tasks.js'
+
+/** Hard cap on auto-recovery attempts per task across its entire lifetime. */
+export const MAX_RECOVERY_ATTEMPTS = 2
+
+/**
+ * Returns true when auto-recovery should be attempted before consuming a retry slot.
+ * Conditions: task has a failure_reason (environment issue) AND is under the recovery cap.
+ */
+export function shouldAttemptRecovery(task: Task): boolean {
+  return !!task.failure_reason && task.recovery_attempts < MAX_RECOVERY_ATTEMPTS
+}
+
+/**
+ * Apply the outcome of a recovery attempt to the DB.
+ *
+ * On 'recovered':
+ *   - Increments recovery_attempts.
+ *   - Returns 'respawn' so the caller can call handleSpawnWorker without consuming a retry.
+ *
+ * On 'unrecoverable' or 'needs_human':
+ *   - Sets retry_count = max_retries to permanently exclude from the retry loop.
+ *   - Writes failure_reason and failure_detail so the orchestrator can escalate with context.
+ *   - Returns 'escalate'.
+ */
+export function applyRecoveryOutcome(
+  db: Database.Database,
+  task: Task,
+  result: RecoverResult,
+): 'respawn' | 'escalate' {
+  const newCount = task.recovery_attempts + 1
+
+  db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
+    task.id,
+    result.verdict === 'recovered' ? 'info' : 'error',
+    `Auto-recovery attempt ${newCount}: ${result.verdict}${result.reason ? ' — ' + result.reason : ''}`,
+  )
+
+  if (result.verdict === 'recovered') {
+    updateTask(db, task.id, { recovery_attempts: newCount })
+    return 'respawn'
+  }
+
+  // unrecoverable or needs_human — exhaust retries so the task stays out of the retry loop
+  updateTask(db, task.id, {
+    status: 'failed',
+    retry_count: task.max_retries,
+    failure_reason: result.verdict,
+    failure_detail: result.reason ?? 'Auto-recovery failed',
+    recovery_attempts: newCount,
+  })
+  return 'escalate'
+}

--- a/src/spawner/index.ts
+++ b/src/spawner/index.ts
@@ -129,18 +129,23 @@ export function spawnWorker(cfg: SpawnConfig): ChildProcess {
   // output (reasoning, tool calls, text) for post-mortem debugging and live
   // tailing with: tail -f <path>
   const claudeDir = join(cfg.worktreePath, '.claude')
-  mkdirSync(claudeDir, { recursive: true })
-  writeFileSync(
-    join(claudeDir, 'settings.local.json'),
-    JSON.stringify({ permissions: { allow:
-      ['Bash(*)', 'Write(*)', 'Edit(*)', 'Read(*)',
-        'mcp__multiclaude-worker__get_my_task',
-        'mcp__multiclaude-worker__report_progress',
-        'mcp__multiclaude-worker__report_done',
-        'mcp__multiclaude-worker__report_blocked'
-      ]
-     } }, null, 2)
-  )
+  try {
+    mkdirSync(claudeDir, { recursive: true })
+    writeFileSync(
+      join(claudeDir, 'settings.local.json'),
+      JSON.stringify({ permissions: { allow:
+        ['Bash(*)', 'Write(*)', 'Edit(*)', 'Read(*)',
+          'mcp__multiclaude-worker__get_my_task',
+          'mcp__multiclaude-worker__report_progress',
+          'mcp__multiclaude-worker__report_done',
+          'mcp__multiclaude-worker__report_blocked'
+        ]
+       } }, null, 2)
+    )
+  } catch (err: unknown) {
+    const detail = err instanceof Error ? err.message : String(err)
+    throw new Error(`settings_write_failed: ${detail}`)
+  }
   const logFd = openSync(workerLogPath(cfg.agentId), 'a')
   const isolation = resolveWorktreeIsolation(cfg.worktreePath)
   return spawn('claude', buildWorkerArgs(cfg), {
@@ -148,6 +153,27 @@ export function spawnWorker(cfg: SpawnConfig): ChildProcess {
     stdio: ['ignore', logFd, logFd],
     env: buildWorkerEnv(cfg.agentId, isolation),
   })
+}
+
+const KNOWN_FAILURE_REASON_PREFIXES = [
+  'tmux_window_create_failed',
+  'tmux_session_create_failed',
+  'settings_write_failed',
+  'agent_launch_failed',
+] as const
+
+/**
+ * Maps a launch error message to a stable machine-readable slug.
+ * Functions in tmux.ts and spawnWorker re-throw errors prefixed with a slug
+ * (e.g. "tmux_window_create_failed: ...") so the classifier can extract it.
+ * Exported for testing.
+ */
+export function classifyLaunchError(msg: string): string {
+  for (const prefix of KNOWN_FAILURE_REASON_PREFIXES) {
+    if (msg.startsWith(prefix + ':') || msg === prefix) return prefix
+  }
+  if (/ENOENT|EACCES|EPERM|EISDIR/.test(msg)) return 'settings_write_failed'
+  return 'agent_launch_failed'
 }
 
 export function writeWorkerMcpConfig(serverPort: number, configDir: string = tmpdir()): string {

--- a/src/spawner/tmux.ts
+++ b/src/spawner/tmux.ts
@@ -430,7 +430,7 @@ export function spawnTmuxWorker(cfg: SpawnConfig): WorkerHandle {
   // Verify the window actually exists; tmux can return a non-zero exit without throwing
   // in some edge cases, leaving us with a stale @NN that targets nothing.
   if (!windowExists(windowId)) {
-    throw new Error(`tmux window creation failed: ${windowId} ('${windowName}') does not exist after new-window`)
+    throw new Error(`tmux_window_create_failed: ${windowId} ('${windowName}') does not exist after new-window`)
   }
 
   // All targeting after this point uses the @NN window ID, not the name.

--- a/src/spawner/tmux.ts
+++ b/src/spawner/tmux.ts
@@ -45,7 +45,12 @@ export function ensureTmuxSession(): string {
     execSync(`tmux has-session -t ${shellQuote(sessionName)}`, { stdio: 'pipe' })
   } catch {
     // Session does not exist — create it detached
-    execSync(`tmux new-session -d -s ${shellQuote(sessionName)}`, { stdio: 'pipe' })
+    try {
+      execSync(`tmux new-session -d -s ${shellQuote(sessionName)}`, { stdio: 'pipe' })
+    } catch (err: unknown) {
+      const detail = err instanceof Error ? err.message : String(err)
+      throw new Error(`tmux_session_create_failed: ${detail}`)
+    }
   }
   return sessionName
 }
@@ -57,12 +62,18 @@ export function ensureTmuxSession(): string {
  * subsequent targeting instead of the name-based session:name form.
  */
 export function createTmuxWindow(sessionName: string, windowName: string, worktreePath: string): string {
-  const windowId = execSync(
-    `tmux new-window -d -P -F '#{window_id}' -t ${shellQuote(sessionName)}: -n ${shellQuote(windowName)} -c ${shellQuote(worktreePath)}`,
-    { encoding: 'utf8', stdio: 'pipe' }
-  ).trim()
+  let windowId: string
+  try {
+    windowId = execSync(
+      `tmux new-window -d -P -F '#{window_id}' -t ${shellQuote(sessionName)}: -n ${shellQuote(windowName)} -c ${shellQuote(worktreePath)}`,
+      { encoding: 'utf8', stdio: 'pipe' }
+    ).trim()
+  } catch (err: unknown) {
+    const detail = err instanceof Error ? err.message : String(err)
+    throw new Error(`tmux_window_create_failed: ${detail}`)
+  }
   if (!windowId) {
-    throw new Error(`Failed to get window ID for newly created tmux window '${windowName}'`)
+    throw new Error(`tmux_window_create_failed: no window ID returned for '${windowName}'`)
   }
   return windowId
 }
@@ -390,17 +401,22 @@ export function writeLaunchScript(cfg: SpawnConfig): string {
  */
 export function spawnTmuxWorker(cfg: SpawnConfig): WorkerHandle {
   const claudeDir = join(cfg.worktreePath, '.claude')
-  mkdirSync(claudeDir, { recursive: true })
-  writeFileSync(
-    join(claudeDir, 'settings.local.json'),
-    JSON.stringify({ permissions: { allow: [
-      'Bash(*)', 'Write(*)', 'Edit(*)', 'Read(*)',
-      'mcp__multiclaude-worker__get_my_task',
-      'mcp__multiclaude-worker__report_progress',
-      'mcp__multiclaude-worker__report_done',
-      'mcp__multiclaude-worker__report_blocked',
-    ] } }, null, 2)
-  )
+  try {
+    mkdirSync(claudeDir, { recursive: true })
+    writeFileSync(
+      join(claudeDir, 'settings.local.json'),
+      JSON.stringify({ permissions: { allow: [
+        'Bash(*)', 'Write(*)', 'Edit(*)', 'Read(*)',
+        'mcp__multiclaude-worker__get_my_task',
+        'mcp__multiclaude-worker__report_progress',
+        'mcp__multiclaude-worker__report_done',
+        'mcp__multiclaude-worker__report_blocked',
+      ] } }, null, 2)
+    )
+  } catch (err: unknown) {
+    const detail = err instanceof Error ? err.message : String(err)
+    throw new Error(`settings_write_failed: ${detail}`)
+  }
 
   const sessionName = ensureTmuxSession()
   // Kill any leftover windows from prior attempts for this task before creating a new one.

--- a/src/spawner/tmux.ts
+++ b/src/spawner/tmux.ts
@@ -2,11 +2,13 @@ import { execSync, spawn } from 'child_process'
 import { writeFileSync, mkdirSync } from 'fs'
 import { join } from 'path'
 
+import type Database from 'better-sqlite3'
 import type { SpawnConfig } from './index.js'
 import { buildWorkerArgs, buildWorkerEnv } from './index.js'
 import { readWorktreeGitDir } from '../git/worktree.js'
 import type { WorktreeIsolation } from './index.js'
 import type { WorkerHandle } from './backend.js'
+import { getTask } from '../server/state/tasks.js'
 
 /**
  * Captures the last `lines` lines of a tmux pane using capture-pane.
@@ -74,6 +76,93 @@ export function killTmuxWindow(windowId: string): void {
     execSync(`tmux kill-window -t ${shellQuote(windowId)}`, { stdio: 'pipe' })
   } catch {
     // Window already dead or tmux unavailable — fine
+  }
+}
+
+export interface TmuxWindowInfo {
+  windowId: string
+  windowName: string
+}
+
+/**
+ * Lists all windows in a tmux session. Returns empty array if tmux unavailable
+ * or the session does not exist.
+ */
+export function listTmuxWindows(sessionName: string): TmuxWindowInfo[] {
+  try {
+    const raw = execSync(
+      `tmux list-windows -t ${shellQuote(sessionName)} -F '#{window_id} #{window_name}'`,
+      { encoding: 'utf8', stdio: 'pipe' }
+    ).trim()
+    if (!raw) return []
+    return raw.split('\n')
+      .map(line => {
+        const spaceIdx = line.indexOf(' ')
+        if (spaceIdx < 0) return null
+        return { windowId: line.slice(0, spaceIdx), windowName: line.slice(spaceIdx + 1) }
+      })
+      .filter((w): w is TmuxWindowInfo => w !== null && w.windowId.startsWith('@'))
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Returns true if a tmux window with the given @NN ID currently exists.
+ */
+export function windowExists(windowId: string): boolean {
+  try {
+    execSync(`tmux display-message -t ${shellQuote(windowId)} -p ''`, { stdio: 'pipe' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Before creating a new window for taskId, kills any existing mc-* windows
+ * whose name is `mc-w-{taskId}` or starts with `mc-w-{taskId}-` (retry
+ * windows). Uses the @NN window ID for reliable targeting.
+ */
+export function reapStaleWindows(sessionName: string, taskId: string): void {
+  const windows = listTmuxWindows(sessionName)
+  const prefix = `mc-w-${taskId}`
+  for (const w of windows) {
+    if (w.windowName === prefix || w.windowName.startsWith(`${prefix}-`)) {
+      killTmuxWindow(w.windowId)
+    }
+  }
+}
+
+/**
+ * Removes mc-* windows from a tmux session that belong to tasks already in a
+ * terminal state (done/failed/cancelled) or absent from the database.
+ * Windows not matching the `mc-` prefix are never touched.
+ */
+export function reapOrphanWindows(
+  db: Database.Database,
+  killWindow: (windowId: string) => void = killTmuxWindow,
+): void {
+  let sessionName: string
+  try {
+    sessionName = ensureTmuxSession()
+  } catch {
+    return
+  }
+  const windows = listTmuxWindows(sessionName)
+  for (const w of windows) {
+    if (!w.windowName.startsWith('mc-')) continue
+    const agentRow = db.prepare(
+      'SELECT task_id FROM agents WHERE tmux_pane = ?'
+    ).get(w.windowId) as { task_id: string | null } | undefined
+    if (!agentRow || !agentRow.task_id) {
+      killWindow(w.windowId)
+      continue
+    }
+    const task = getTask(db, agentRow.task_id)
+    if (!task || task.status === 'done' || task.status === 'failed' || task.status === 'cancelled') {
+      killWindow(w.windowId)
+    }
   }
 }
 
@@ -314,10 +403,20 @@ export function spawnTmuxWorker(cfg: SpawnConfig): WorkerHandle {
   )
 
   const sessionName = ensureTmuxSession()
+  // Kill any leftover windows from prior attempts for this task before creating a new one.
+  reapStaleWindows(sessionName, cfg.taskId)
+
   // Window name is unique per agent attempt — different agent IDs for retries
   // prevent tmux from resolving -t to a stale dead window from a prior attempt.
   const windowName = `mc-${cfg.agentId}`
   const windowId = createTmuxWindow(sessionName, windowName, cfg.worktreePath)
+
+  // Verify the window actually exists; tmux can return a non-zero exit without throwing
+  // in some edge cases, leaving us with a stale @NN that targets nothing.
+  if (!windowExists(windowId)) {
+    throw new Error(`tmux window creation failed: ${windowId} ('${windowName}') does not exist after new-window`)
+  }
+
   // All targeting after this point uses the @NN window ID, not the name.
   const panePid = getTmuxPanePid(windowId)
 

--- a/tests/git/is-merged-into.test.ts
+++ b/tests/git/is-merged-into.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for isMergedInto — the ancestor check used by handleReportDone
+ * to distinguish "merge landed, cleanup failed" from genuine merge failures.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { isMergedInto, ensureIntegrationBranch, mergeWorktreeBranch } from '../../src/git/merge.js'
+import { createWorktree, removeWorktree } from '../../src/git/worktree.js'
+import { execSync } from 'child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'mc-is-merged-test-'))
+  execSync('git init', { cwd: dir })
+  execSync('git config user.email "test@test.com"', { cwd: dir })
+  execSync('git config user.name "Test"', { cwd: dir })
+  execSync('echo "init" > README.md && git add . && git commit -m "init"', { cwd: dir })
+  return dir
+}
+
+describe('isMergedInto', () => {
+  let repoPath: string
+
+  beforeEach(() => {
+    repoPath = makeRepo()
+  })
+
+  afterEach(() => {
+    rmSync(repoPath, { recursive: true, force: true })
+  })
+
+  it('returns true when task branch is merged into integration branch', async () => {
+    const runId = 'merged-true'
+    await ensureIntegrationBranch(repoPath, runId)
+    const info = await createWorktree(repoPath, 'task-a', 'feat: task-a')
+    writeFileSync(join(info.path, 'a.ts'), 'export const a = 1')
+    execSync('git add . && git commit -m "add a"', { cwd: info.path })
+
+    await mergeWorktreeBranch(repoPath, info.branch, runId)
+
+    const result = await isMergedInto(repoPath, info.branch, `mc/run-${runId}`)
+    expect(result).toBe(true)
+
+    await removeWorktree(repoPath, info)
+  })
+
+  it('returns false when task branch is NOT merged', async () => {
+    const runId = 'not-merged'
+    await ensureIntegrationBranch(repoPath, runId)
+    const info = await createWorktree(repoPath, 'task-b', 'feat: task-b')
+    writeFileSync(join(info.path, 'b.ts'), 'export const b = 2')
+    execSync('git add . && git commit -m "add b"', { cwd: info.path })
+
+    // Deliberately do NOT merge — task branch is NOT an ancestor of the run branch
+    const result = await isMergedInto(repoPath, info.branch, `mc/run-${runId}`)
+    expect(result).toBe(false)
+
+    await removeWorktree(repoPath, info)
+  })
+
+  it('returns false without throwing when local task branch does not exist', async () => {
+    const runId = 'missing-branch'
+    await ensureIntegrationBranch(repoPath, runId)
+
+    await expect(
+      isMergedInto(repoPath, 'feature/nonexistent-task', `mc/run-${runId}`)
+    ).resolves.toBe(false)
+  })
+
+  it('returns true via origin/<branch> when local task branch has been deleted after merge', async () => {
+    // Set up a bare repo as origin so we can push the task branch there
+    const originPath = mkdtempSync(join(tmpdir(), 'mc-is-merged-origin-'))
+    try {
+      execSync('git init --bare', { cwd: originPath })
+      execSync(`git remote add origin ${originPath}`, { cwd: repoPath })
+      execSync('git push -u origin HEAD:main', { cwd: repoPath })
+
+      const runId = 'deleted-local-branch'
+      await ensureIntegrationBranch(repoPath, runId)
+      const info = await createWorktree(repoPath, 'task-c', 'feat: task-c')
+      writeFileSync(join(info.path, 'c.ts'), 'export const c = 3')
+      execSync('git add . && git commit -m "add c"', { cwd: info.path })
+
+      // Push task branch to origin BEFORE removing local
+      execSync(`git push origin ${info.branch}`, { cwd: repoPath })
+
+      // Merge into integration branch
+      await mergeWorktreeBranch(repoPath, info.branch, runId)
+
+      // Delete the local task branch — this simulates post-merge cleanup having run
+      execSync(`git branch -D ${info.branch}`, { cwd: repoPath })
+
+      // isMergedInto must still return true via origin/<branch>
+      const result = await isMergedInto(repoPath, info.branch, `mc/run-${runId}`)
+      expect(result).toBe(true)
+    } finally {
+      rmSync(originPath, { recursive: true, force: true })
+    }
+  })
+
+  it('returns false without throwing when branch is absent both locally and on origin', async () => {
+    // Origin exists but the task branch was never pushed there
+    const originPath = mkdtempSync(join(tmpdir(), 'mc-is-merged-origin2-'))
+    try {
+      execSync('git init --bare', { cwd: originPath })
+      execSync(`git remote add origin ${originPath}`, { cwd: repoPath })
+      execSync('git push -u origin HEAD:main', { cwd: repoPath })
+
+      const runId = 'absent-everywhere'
+      await ensureIntegrationBranch(repoPath, runId)
+
+      await expect(
+        isMergedInto(repoPath, 'feature/ghost-branch', `mc/run-${runId}`)
+      ).resolves.toBe(false)
+    } finally {
+      rmSync(originPath, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/git/is-merged-into.test.ts
+++ b/tests/git/is-merged-into.test.ts
@@ -82,14 +82,14 @@ describe('isMergedInto', () => {
       writeFileSync(join(info.path, 'c.ts'), 'export const c = 3')
       execSync('git add . && git commit -m "add c"', { cwd: info.path })
 
-      // Push task branch to origin BEFORE removing local
+      // Push task branch to origin BEFORE cleanup
       execSync(`git push origin ${info.branch}`, { cwd: repoPath })
 
       // Merge into integration branch
       await mergeWorktreeBranch(repoPath, info.branch, runId)
 
-      // Delete the local task branch — this simulates post-merge cleanup having run
-      execSync(`git branch -D ${info.branch}`, { cwd: repoPath })
+      // Run actual post-merge cleanup: removes worktree + deletes local branch
+      await removeWorktree(repoPath, info)
 
       // isMergedInto must still return true via origin/<branch>
       const result = await isMergedInto(repoPath, info.branch, `mc/run-${runId}`)

--- a/tests/git/merge-conflict-reduction.test.ts
+++ b/tests/git/merge-conflict-reduction.test.ts
@@ -111,7 +111,7 @@ describe('update-before-merge', () => {
     await removeWorktree(repoPath, info)
   })
 
-  it('handles three sequential merges with stale task branches', async () => {
+  it('handles three sequential merges with stale task branches', { timeout: 15000 }, async () => {
     const runId = 'three-tasks'
     await ensureIntegrationBranch(repoPath, runId)
     const integBranch = `mc/run-${runId}`

--- a/tests/git/worktree-config-isolation.test.ts
+++ b/tests/git/worktree-config-isolation.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createWorktree, removeWorktree, sanitizeParentGitConfig, assertSharedConfigClean } from '../../src/git/worktree.js'
+import { buildWorkerEnv } from '../../src/spawner/index.js'
+import { execSync } from 'child_process'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, realpathSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+function git(cmd: string, cwd: string, env?: NodeJS.ProcessEnv): string {
+  return execSync(cmd, { cwd, env, encoding: 'utf8' }).trim()
+}
+
+describe('worktree config isolation (#100)', () => {
+  let parentRepo: string
+  let savedGitEnv: Record<string, string | undefined>
+
+  beforeEach(() => {
+    savedGitEnv = {
+      GIT_DIR: process.env.GIT_DIR,
+      GIT_WORK_TREE: process.env.GIT_WORK_TREE,
+      GIT_CEILING_DIRECTORIES: process.env.GIT_CEILING_DIRECTORIES,
+    }
+    delete process.env.GIT_DIR
+    delete process.env.GIT_WORK_TREE
+    delete process.env.GIT_CEILING_DIRECTORIES
+
+    parentRepo = realpathSync(mkdtempSync(join(tmpdir(), 'mc-config-iso-test-')))
+    git('git init', parentRepo)
+    git('git config user.email "test@test.com"', parentRepo)
+    git('git config user.name "Test"', parentRepo)
+    git('echo "init" > README.md && git add . && git commit -m "init"', parentRepo)
+  })
+
+  afterEach(() => {
+    for (const [key, val] of Object.entries(savedGitEnv)) {
+      if (val !== undefined) process.env[key] = val
+      else delete process.env[key]
+    }
+    rmSync(parentRepo, { recursive: true, force: true })
+  })
+
+  it('parent repo resolves toplevel and is-inside-work-tree after worktree create+delete', async () => {
+    const info = await createWorktree(parentRepo, 'cfg-1', 'feat: config test')
+    await removeWorktree(parentRepo, info)
+
+    expect(git('git rev-parse --is-inside-work-tree', parentRepo)).toBe('true')
+    expect(git('git rev-parse --show-toplevel', parentRepo)).toBe(parentRepo)
+  })
+
+  it('parent .git/config is byte-identical before and after full worktree lifecycle', async () => {
+    const configPath = join(parentRepo, '.git', 'config')
+    const configBefore = readFileSync(configPath, 'utf8')
+
+    const info = await createWorktree(parentRepo, 'cfg-2', 'feat: byte identical')
+    const env = buildWorkerEnv('w-cfg-2', { worktreePath: info.path, gitDir: info.gitDir })
+
+    writeFileSync(join(info.path, 'feature.ts'), 'export const x = 1')
+    git('git add feature.ts && git commit -m "add feature"', info.path, env)
+
+    await removeWorktree(parentRepo, info)
+
+    const configAfter = readFileSync(configPath, 'utf8')
+    expect(configAfter).toBe(configBefore)
+  })
+
+  it('worker with isolation env vars cannot commit to parent repo branch (#96)', async () => {
+    const info = await createWorktree(parentRepo, 'cfg-3', 'feat: isolation check')
+    const env = buildWorkerEnv('w-cfg-3', { worktreePath: info.path, gitDir: info.gitDir })
+
+    writeFileSync(join(info.path, 'isolated.ts'), 'export const isolated = true')
+    git('git add isolated.ts && git commit -m "isolated commit"', info.path, env)
+
+    expect(git(`git log --oneline ${info.branch}`, parentRepo)).toContain('isolated commit')
+
+    const parentBranch = git('git branch --show-current', parentRepo)
+    expect(git(`git log --oneline ${parentBranch}`, parentRepo)).not.toContain('isolated commit')
+
+    await removeWorktree(parentRepo, info)
+  })
+
+  it('removeWorktree cleans up stray core.worktree from parent config', async () => {
+    const info = await createWorktree(parentRepo, 'cfg-4', 'feat: cleanup test')
+
+    git(`git config --local core.worktree "${info.path}"`, parentRepo)
+    expect(git('git config --local --get core.worktree', parentRepo)).toBe(info.path)
+
+    await removeWorktree(parentRepo, info)
+
+    expect(git('git rev-parse --is-inside-work-tree', parentRepo)).toBe('true')
+    expect(git('git rev-parse --show-toplevel', parentRepo)).toBe(parentRepo)
+
+    let coreWorktree: string | null = null
+    try {
+      coreWorktree = git('git config --local --get core.worktree', parentRepo)
+    } catch {
+      // exit code 1 = key not found — expected
+    }
+    expect(coreWorktree).toBeNull()
+  })
+
+  it('sanitizeParentGitConfig removes stray core.worktree', async () => {
+    git('git config --local core.worktree "/tmp/deleted-worktree"', parentRepo)
+    expect(git('git config --local --get core.worktree', parentRepo)).toBe('/tmp/deleted-worktree')
+
+    await sanitizeParentGitConfig(parentRepo)
+
+    let after: string | null = null
+    try {
+      after = git('git config --local --get core.worktree', parentRepo)
+    } catch { /* not set */ }
+    expect(after).toBeNull()
+  })
+
+  it('sanitizeParentGitConfig is a no-op when config is clean', async () => {
+    const configPath = join(parentRepo, '.git', 'config')
+    const configBefore = readFileSync(configPath, 'utf8')
+
+    await sanitizeParentGitConfig(parentRepo)
+
+    const configAfter = readFileSync(configPath, 'utf8')
+    expect(configAfter).toBe(configBefore)
+  })
+
+  it('assertSharedConfigClean throws when core.worktree is set', async () => {
+    git('git config --local core.worktree "/tmp/bad-path"', parentRepo)
+    await expect(assertSharedConfigClean(parentRepo)).rejects.toThrow('core.worktree')
+  })
+
+  it('assertSharedConfigClean passes when config is clean', async () => {
+    await expect(assertSharedConfigClean(parentRepo)).resolves.toBeUndefined()
+  })
+
+  it('multiple worktree create+delete cycles leave parent config untouched', async () => {
+    const configPath = join(parentRepo, '.git', 'config')
+    const configBefore = readFileSync(configPath, 'utf8')
+
+    for (let i = 0; i < 3; i++) {
+      const info = await createWorktree(parentRepo, `cfg-multi-${i}`, `feat: cycle ${i}`)
+      const env = buildWorkerEnv(`w-cfg-multi-${i}`, { worktreePath: info.path, gitDir: info.gitDir })
+      writeFileSync(join(info.path, `file-${i}.ts`), `export const x = ${i}`)
+      git(`git add file-${i}.ts && git commit -m "commit ${i}"`, info.path, env)
+      await removeWorktree(parentRepo, info)
+    }
+
+    const configAfter = readFileSync(configPath, 'utf8')
+    expect(configAfter).toBe(configBefore)
+
+    expect(git('git rev-parse --is-inside-work-tree', parentRepo)).toBe('true')
+  })
+})

--- a/tests/git/worktree-preflight.test.ts
+++ b/tests/git/worktree-preflight.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createWorktree, removeWorktree, preflightReconcile, isProtectedBranch } from '../../src/git/worktree.js'
+import { simpleGit } from 'simple-git'
+import { execSync } from 'child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+describe('isProtectedBranch', () => {
+  it('returns true for main', () => {
+    expect(isProtectedBranch('main')).toBe(true)
+  })
+
+  it('returns true for master', () => {
+    expect(isProtectedBranch('master')).toBe(true)
+  })
+
+  it('returns true for mc/run-* branches', () => {
+    expect(isProtectedBranch('mc/run-abc123')).toBe(true)
+    expect(isProtectedBranch('mc/run-479497dd-24ad-46f3')).toBe(true)
+  })
+
+  it('returns false for task and feature branches', () => {
+    expect(isProtectedBranch('feature/add-auth')).toBe(false)
+    expect(isProtectedBranch('mc/task-1')).toBe(false)
+    expect(isProtectedBranch('fix/broken-config')).toBe(false)
+  })
+})
+
+describe('worktree preflight reconcile', () => {
+  let repoPath: string
+  const worktrees: string[] = []
+
+  beforeEach(() => {
+    repoPath = mkdtempSync(join(tmpdir(), 'mc-preflight-'))
+    execSync('git init', { cwd: repoPath })
+    execSync('git config user.email "test@test.com"', { cwd: repoPath })
+    execSync('git config user.name "Test"', { cwd: repoPath })
+    execSync('echo "init" > README.md && git add . && git commit -m "init"', { cwd: repoPath })
+    worktrees.length = 0
+  })
+
+  afterEach(() => {
+    for (const wt of worktrees) {
+      try { execSync(`git worktree remove --force "${wt}"`, { cwd: repoPath }) } catch {}
+      rmSync(wt, { recursive: true, force: true })
+    }
+    try { execSync('git worktree prune', { cwd: repoPath }) } catch {}
+    rmSync(repoPath, { recursive: true, force: true })
+  })
+
+  it('prunes a worktree whose directory no longer exists', async () => {
+    const info1 = await createWorktree(repoPath, 'task-stale')
+    const stalePath = info1.path
+
+    // Delete the directory to simulate a crash — worktree entry remains
+    rmSync(stalePath, { recursive: true, force: true })
+    const before = execSync('git worktree list', { cwd: repoPath }).toString()
+    expect(before).toContain(stalePath)
+
+    // Second createWorktree should prune the stale entry and succeed
+    const info2 = await createWorktree(repoPath, 'task-stale')
+    worktrees.push(info2.path)
+
+    expect(info2.branch).toBe('mc/task-stale')
+    // Pruning cleared the stale worktree, then the zero-commit branch was deleted
+    expect(info2.reconcileActions.some(a => a.type === 'delete-branch')).toBe(true)
+
+    // Stale entry should be gone
+    const after = execSync('git worktree list', { cwd: repoPath }).toString()
+    expect(after).not.toContain(stalePath)
+    expect(after).toContain(info2.path)
+  })
+
+  it('reuses a branch with zero unique commits', async () => {
+    // Create an orphan branch at HEAD (no unique commits vs HEAD)
+    execSync('git branch mc/task-zero', { cwd: repoPath })
+
+    const info = await createWorktree(repoPath, 'task-zero')
+    worktrees.push(info.path)
+
+    expect(info.branch).toBe('mc/task-zero')
+    expect(info.reconcileActions.some(a => a.type === 'delete-branch')).toBe(true)
+    expect(info.priorBranch).toBeUndefined()
+  })
+
+  it('preserves a branch with unique commits by allocating a new name', async () => {
+    // Create a branch with a unique commit
+    execSync('git checkout -b mc/task-preserve', { cwd: repoPath })
+    writeFileSync(join(repoPath, 'unique.txt'), 'unique work')
+    execSync('git add . && git commit -m "unique work"', { cwd: repoPath })
+    execSync('git checkout -', { cwd: repoPath })
+
+    const info = await createWorktree(repoPath, 'task-preserve')
+    worktrees.push(info.path)
+
+    expect(info.branch).toBe('mc/task-preserve-attempt-2')
+    expect(info.priorBranch).toBe('mc/task-preserve')
+    expect(info.reconcileActions.some(a => a.type === 'allocate-suffix')).toBe(true)
+
+    // Original branch must still exist with its commits
+    const branches = execSync('git branch', { cwd: repoPath }).toString()
+    expect(branches).toContain('mc/task-preserve')
+    const log = execSync('git log --oneline mc/task-preserve', { cwd: repoPath }).toString()
+    expect(log).toContain('unique work')
+  })
+
+  it('refuses to reconcile main branch', async () => {
+    const git = simpleGit(repoPath)
+    await expect(preflightReconcile(git, 'main')).rejects.toThrow(/protected branch/)
+  })
+
+  it('refuses to reconcile master branch', async () => {
+    const git = simpleGit(repoPath)
+    await expect(preflightReconcile(git, 'master')).rejects.toThrow(/protected branch/)
+  })
+
+  it('refuses to reconcile mc/run-* integration branch', async () => {
+    const git = simpleGit(repoPath)
+    await expect(preflightReconcile(git, 'mc/run-abc123')).rejects.toThrow(/protected branch/)
+  })
+
+  it('removes a registered worktree when its working tree is clean', async () => {
+    const info1 = await createWorktree(repoPath, 'task-clean-wt')
+    // Worktree exists and is clean (no changes made)
+
+    const info2 = await createWorktree(repoPath, 'task-clean-wt')
+    worktrees.push(info2.path)
+
+    expect(info2.branch).toBe('mc/task-clean-wt')
+    expect(info2.reconcileActions.some(a => a.type === 'remove-worktree')).toBe(true)
+
+    // First worktree path should no longer be a worktree
+    const wtList = execSync('git worktree list', { cwd: repoPath }).toString()
+    expect(wtList).not.toContain(info1.path)
+    expect(wtList).toContain(info2.path)
+  })
+
+  it('returns empty reconcileActions when no cleanup is needed', async () => {
+    const info = await createWorktree(repoPath, 'task-clean')
+    worktrees.push(info.path)
+
+    expect(info.reconcileActions).toEqual([])
+    expect(info.priorBranch).toBeUndefined()
+  })
+
+  it('reconcile actions contain structured detail strings', async () => {
+    // Create a branch with unique commits to trigger allocate-suffix
+    execSync('git checkout -b mc/task-detail', { cwd: repoPath })
+    writeFileSync(join(repoPath, 'detail.txt'), 'detail work')
+    execSync('git add . && git commit -m "detail commit"', { cwd: repoPath })
+    execSync('git checkout -', { cwd: repoPath })
+
+    const info = await createWorktree(repoPath, 'task-detail')
+    worktrees.push(info.path)
+
+    const suffixAction = info.reconcileActions.find(a => a.type === 'allocate-suffix')
+    expect(suffixAction).toBeDefined()
+    expect(suffixAction!.target).toBe('mc/task-detail-attempt-2')
+    expect(suffixAction!.detail).toContain('mc/task-detail')
+    expect(suffixAction!.detail).toContain('unique commit')
+  })
+
+  it('allocates incrementing suffixes when prior attempts exist', async () => {
+    // Create branches simulating two prior attempts
+    execSync('git checkout -b mc/task-multi', { cwd: repoPath })
+    writeFileSync(join(repoPath, 'v1.txt'), 'v1')
+    execSync('git add . && git commit -m "v1"', { cwd: repoPath })
+    execSync('git checkout -', { cwd: repoPath })
+
+    execSync('git checkout -b mc/task-multi-attempt-2', { cwd: repoPath })
+    writeFileSync(join(repoPath, 'v2.txt'), 'v2')
+    execSync('git add . && git commit -m "v2"', { cwd: repoPath })
+    execSync('git checkout -', { cwd: repoPath })
+
+    const info = await createWorktree(repoPath, 'task-multi')
+    worktrees.push(info.path)
+
+    expect(info.branch).toBe('mc/task-multi-attempt-3')
+    expect(info.priorBranch).toBe('mc/task-multi')
+  })
+
+  it('uses baseBranch for unique commit comparison when provided', async () => {
+    // Create a base branch ahead of HEAD
+    execSync('git checkout -b base-branch', { cwd: repoPath })
+    writeFileSync(join(repoPath, 'base.txt'), 'base work')
+    execSync('git add . && git commit -m "base commit"', { cwd: repoPath })
+
+    // Create a task branch from base-branch (no unique commits vs base)
+    execSync('git branch mc/task-based', { cwd: repoPath })
+    execSync('git checkout -', { cwd: repoPath })
+
+    // mc/task-based has commits vs HEAD but zero vs base-branch
+    const info = await createWorktree(repoPath, 'task-based', undefined, 'base-branch')
+    worktrees.push(info.path)
+
+    expect(info.branch).toBe('mc/task-based')
+    expect(info.reconcileActions.some(a => a.type === 'delete-branch')).toBe(true)
+    expect(info.priorBranch).toBeUndefined()
+  })
+})

--- a/tests/spawner/auto-recovery-watcher.test.ts
+++ b/tests/spawner/auto-recovery-watcher.test.ts
@@ -1,0 +1,363 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Mock tmux so handleRecoverTask doesn't need a real tmux session.
+const { mockKillTmuxWindow, mockEnsureTmuxSession, mockReapStaleWindows } = vi.hoisted(() => ({
+  mockKillTmuxWindow: vi.fn(),
+  mockEnsureTmuxSession: vi.fn(() => 'multiclaude'),
+  mockReapStaleWindows: vi.fn(),
+}))
+
+vi.mock('../../src/spawner/tmux.js', () => ({
+  killTmuxWindow: mockKillTmuxWindow,
+  ensureTmuxSession: mockEnsureTmuxSession,
+  reapStaleWindows: mockReapStaleWindows,
+  captureTmuxPane: vi.fn(() => ''),
+  spawnTmuxWorker: vi.fn(),
+  createTmuxWindow: vi.fn(() => '@1'),
+  getTmuxPanePid: vi.fn(() => undefined),
+  sendTmuxKeys: vi.fn(),
+  writeLaunchScript: vi.fn(() => '/tmp/worker-launch.sh'),
+  sendToPane: vi.fn(() => ({ sent: true, enterRetries: 0 })),
+  capturePaneText: vi.fn(() => ''),
+  classifyComposerState: vi.fn(() => 'empty'),
+  listTmuxWindows: vi.fn(() => []),
+  reapOrphanWindows: vi.fn(),
+  windowExists: vi.fn(() => true),
+  getChildProcessPid: vi.fn(() => undefined),
+  stripAnsiDim: vi.fn((s: string) => s),
+  stripBoxDrawing: vi.fn((s: string) => s),
+  cleanComposerLine: vi.fn((s: string) => s),
+}))
+
+import { createDb, closeDb } from '../../src/server/state/db.js'
+import { createTask, getTask, updateTask } from '../../src/server/state/tasks.js'
+import { handleSpawnWorker } from '../../src/server/tools/orchestrator.js'
+import {
+  shouldAttemptRecovery,
+  applyRecoveryOutcome,
+  MAX_RECOVERY_ATTEMPTS,
+} from '../../src/spawner/auto-recovery.js'
+import { execSync } from 'child_process'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type Database from 'better-sqlite3'
+import type { Task } from '../../src/server/state/tasks.js'
+
+// Strip worktree isolation vars so simpleGit works against a real test repo.
+delete process.env.GIT_DIR
+delete process.env.GIT_WORK_TREE
+delete process.env.GIT_CEILING_DIRECTORIES
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 't1',
+    title: 'Test task',
+    description: null,
+    status: 'failed',
+    model: 'sonnet',
+    effort: 'high',
+    retry_count: 0,
+    max_retries: 3,
+    worktree_path: null,
+    branch: null,
+    head_sha: null,
+    repo_path: null,
+    agent_id: null,
+    started_at: null,
+    duration_seconds: null,
+    input_tokens: null,
+    output_tokens: null,
+    total_tokens: null,
+    cost_usd: null,
+    run_id: null,
+    ticket: null,
+    failure_reason: 'worktree_branch_exists',
+    failure_detail: null,
+    recovery_attempts: 0,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+// ─── shouldAttemptRecovery ────────────────────────────────────────────────────
+
+describe('shouldAttemptRecovery', () => {
+  it('returns true when task has a failure_reason and is under the cap', () => {
+    expect(shouldAttemptRecovery(makeTask({ failure_reason: 'worktree_branch_exists', recovery_attempts: 0 }))).toBe(true)
+    expect(shouldAttemptRecovery(makeTask({ failure_reason: 'agent_launch_failed', recovery_attempts: MAX_RECOVERY_ATTEMPTS - 1 }))).toBe(true)
+  })
+
+  it('returns false when recovery_attempts has hit the cap', () => {
+    expect(shouldAttemptRecovery(makeTask({ failure_reason: 'worktree_branch_exists', recovery_attempts: MAX_RECOVERY_ATTEMPTS }))).toBe(false)
+    expect(shouldAttemptRecovery(makeTask({ failure_reason: 'worktree_branch_exists', recovery_attempts: MAX_RECOVERY_ATTEMPTS + 1 }))).toBe(false)
+  })
+
+  it('returns false when there is no failure_reason', () => {
+    expect(shouldAttemptRecovery(makeTask({ failure_reason: null, recovery_attempts: 0 }))).toBe(false)
+  })
+})
+
+// ─── applyRecoveryOutcome ─────────────────────────────────────────────────────
+
+describe('applyRecoveryOutcome', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = createDb(':memory:')
+    createTask(db, { id: 't1', title: 'Test task', max_retries: 3 })
+    updateTask(db, 't1', { status: 'failed', failure_reason: 'worktree_branch_exists', recovery_attempts: 0 })
+  })
+
+  afterEach(() => {
+    closeDb(db)
+  })
+
+  describe('recovered verdict', () => {
+    it('returns respawn and increments recovery_attempts', () => {
+      const task = getTask(db, 't1')!
+      const outcome = applyRecoveryOutcome(db, task, { task_id: 't1', verdict: 'recovered', actions: [] })
+
+      expect(outcome).toBe('respawn')
+      const updated = getTask(db, 't1')!
+      expect(updated.recovery_attempts).toBe(1)
+      // Status is not changed by applyRecoveryOutcome on success (handleRecoverTask already reset it to pending)
+      expect(updated.failure_reason).toBe('worktree_branch_exists')  // applyRecoveryOutcome doesn't touch failure_reason on success
+    })
+
+    it('writes an info log for the recovery attempt', () => {
+      const task = getTask(db, 't1')!
+      applyRecoveryOutcome(db, task, { task_id: 't1', verdict: 'recovered', actions: [] })
+
+      const log = db.prepare(
+        "SELECT level, message FROM logs WHERE task_id = 't1' ORDER BY id DESC LIMIT 1"
+      ).get() as { level: string; message: string }
+      expect(log.level).toBe('info')
+      expect(log.message).toContain('Auto-recovery attempt 1')
+      expect(log.message).toContain('recovered')
+    })
+
+    it('increments from the captured snapshot value, not the DB value', () => {
+      // recovery_attempts = 1 in the snapshot
+      updateTask(db, 't1', { recovery_attempts: 1 })
+      const task = getTask(db, 't1')!
+      expect(task.recovery_attempts).toBe(1)
+
+      applyRecoveryOutcome(db, task, { task_id: 't1', verdict: 'recovered', actions: [] })
+
+      const updated = getTask(db, 't1')!
+      expect(updated.recovery_attempts).toBe(2)
+    })
+  })
+
+  describe('needs_human verdict', () => {
+    it('returns escalate and exhausts retry_count', () => {
+      const task = getTask(db, 't1')!
+      const outcome = applyRecoveryOutcome(db, task, {
+        task_id: 't1',
+        verdict: 'needs_human',
+        reason: 'tmux session creation failed',
+        actions: [],
+      })
+
+      expect(outcome).toBe('escalate')
+      const updated = getTask(db, 't1')!
+      expect(updated.retry_count).toBe(3)  // max_retries — excluded from future retry loops
+      expect(updated.status).toBe('failed')
+      expect(updated.failure_reason).toBe('needs_human')
+      expect(updated.failure_detail).toContain('tmux session creation failed')
+      expect(updated.recovery_attempts).toBe(1)
+    })
+
+    it('writes an error log for the recovery attempt', () => {
+      const task = getTask(db, 't1')!
+      applyRecoveryOutcome(db, task, {
+        task_id: 't1',
+        verdict: 'needs_human',
+        reason: 'requires manual fix',
+        actions: [],
+      })
+
+      const log = db.prepare(
+        "SELECT level, message FROM logs WHERE task_id = 't1' ORDER BY id DESC LIMIT 1"
+      ).get() as { level: string; message: string }
+      expect(log.level).toBe('error')
+      expect(log.message).toContain('needs_human')
+      expect(log.message).toContain('requires manual fix')
+    })
+
+    it('task is NOT picked up by a subsequent failed-task scan (retry exhausted)', () => {
+      const task = getTask(db, 't1')!
+      applyRecoveryOutcome(db, task, { task_id: 't1', verdict: 'needs_human', reason: 'env broken', actions: [] })
+
+      const updated = getTask(db, 't1')!
+      // Simulated retry filter: status='failed' AND retry_count < max_retries
+      expect(updated.status).toBe('failed')
+      expect(updated.retry_count).toBe(updated.max_retries)
+      // → filter excludes it (retry_count < max_retries is false)
+    })
+  })
+
+  describe('unrecoverable verdict', () => {
+    it('returns escalate and exhausts retry_count', () => {
+      const task = getTask(db, 't1')!
+      const outcome = applyRecoveryOutcome(db, task, {
+        task_id: 't1',
+        verdict: 'unrecoverable',
+        reason: 'git reconciliation failed',
+        actions: [],
+      })
+
+      expect(outcome).toBe('escalate')
+      const updated = getTask(db, 't1')!
+      expect(updated.retry_count).toBe(3)
+      expect(updated.failure_reason).toBe('unrecoverable')
+      expect(updated.failure_detail).toContain('git reconciliation failed')
+    })
+  })
+})
+
+// ─── Recovery cap ─────────────────────────────────────────────────────────────
+
+describe('recovery cap behaviour', () => {
+  it('shouldAttemptRecovery returns false when cap is reached', () => {
+    const task = makeTask({ failure_reason: 'tmux_window_create_failed', recovery_attempts: MAX_RECOVERY_ATTEMPTS })
+    expect(shouldAttemptRecovery(task)).toBe(false)
+  })
+
+  it('task with recovery_attempts at cap is identified as needing escalation rather than recovery', () => {
+    // Callers should check shouldAttemptRecovery first; when it returns false
+    // for a task with a failure_reason, they escalate permanently.
+    const task = makeTask({ failure_reason: 'worktree_branch_exists', recovery_attempts: MAX_RECOVERY_ATTEMPTS })
+    expect(shouldAttemptRecovery(task)).toBe(false)
+    expect(task.failure_reason).toBeTruthy()  // there IS a failure_reason, but cap is hit
+  })
+})
+
+// ─── Integration: recovery succeeds → re-spawn proceeds ──────────────────────
+
+describe('integration: recovery succeeds and re-spawn proceeds', () => {
+  let db: Database.Database
+  let repoPath: string
+
+  beforeEach(() => {
+    db = createDb(':memory:')
+    repoPath = mkdtempSync(join(tmpdir(), 'mc-ar-test-'))
+    execSync('git init', { cwd: repoPath })
+    execSync('git config user.email "test@test.com"', { cwd: repoPath })
+    execSync('git config user.name "Test"', { cwd: repoPath })
+    execSync('echo "init" > README.md && git add . && git commit --no-gpg-sign -m "init"', { cwd: repoPath })
+    mockKillTmuxWindow.mockReset()
+    mockEnsureTmuxSession.mockReset()
+    mockEnsureTmuxSession.mockReturnValue('multiclaude')
+  })
+
+  afterEach(() => {
+    closeDb(db)
+    try { execSync('git worktree prune', { cwd: repoPath }) } catch {}
+    rmSync(repoPath, { recursive: true, force: true })
+  })
+
+  it('after applyRecoveryOutcome(recovered), handleSpawnWorker succeeds without incrementing retry_count', async () => {
+    createTask(db, { id: 't-respawn', title: 'Respawn test' })
+    updateTask(db, 't-respawn', {
+      status: 'failed',
+      failure_reason: 'worktree_branch_exists',
+      recovery_attempts: 0,
+      repo_path: repoPath,
+    })
+
+    const task = getTask(db, 't-respawn')!
+    expect(task.retry_count).toBe(0)
+
+    // Simulate: handleRecoverTask returned 'recovered' (environment repaired, task reset to pending)
+    updateTask(db, 't-respawn', {
+      status: 'pending',
+      failure_reason: undefined,  // cleared by handleRecoverTask
+      agent_id: undefined,
+      worktree_path: undefined,
+      branch: undefined,
+      head_sha: undefined,
+    })
+    const outcome = applyRecoveryOutcome(db, task, { task_id: 't-respawn', verdict: 'recovered', actions: [] })
+    expect(outcome).toBe('respawn')
+
+    // Re-spawn: retry_count must NOT be incremented
+    const result = await handleSpawnWorker(db, 't-respawn', 'w-t-respawn-r1', { cwd: repoPath })
+    expect(result.ok).toBe(true)
+
+    const afterSpawn = getTask(db, 't-respawn')!
+    expect(afterSpawn.status).toBe('in_progress')
+    expect(afterSpawn.retry_count).toBe(0)   // <-- key assertion: retry NOT consumed
+    expect(afterSpawn.recovery_attempts).toBe(1)
+
+    // Cleanup worktree
+    if (afterSpawn.worktree_path) {
+      try { rmSync(afterSpawn.worktree_path, { recursive: true, force: true }) } catch {}
+    }
+  })
+
+  it('needs_human verdict surfaces to orchestrator without further retries', async () => {
+    createTask(db, { id: 't-nh', title: 'Needs human test', max_retries: 3 })
+    updateTask(db, 't-nh', {
+      status: 'failed',
+      failure_reason: 'tmux_session_create_failed',
+      recovery_attempts: 0,
+    })
+
+    const task = getTask(db, 't-nh')!
+    expect(shouldAttemptRecovery(task)).toBe(true)
+
+    applyRecoveryOutcome(db, task, {
+      task_id: 't-nh',
+      verdict: 'needs_human',
+      reason: 'Tmux session creation previously failed — ensure tmux is available before re-spawning',
+      actions: [],
+    })
+
+    const updated = getTask(db, 't-nh')!
+    // Orchestrator sees failure_reason='needs_human' with full context
+    expect(updated.failure_reason).toBe('needs_human')
+    expect(updated.failure_detail).toContain('tmux')
+
+    // No further retries: retry_count exhausted
+    expect(updated.retry_count).toBe(updated.max_retries)
+    expect(updated.status).toBe('failed')
+
+    // Verify the retry loop filter would exclude this task
+    const retriableCount = db.prepare(
+      "SELECT COUNT(*) AS cnt FROM tasks WHERE status = 'failed' AND retry_count < max_retries AND id = 't-nh'"
+    ).get() as { cnt: number }
+    expect(retriableCount.cnt).toBe(0)
+  })
+
+  it('recovery cap reached: task fails permanently without consuming a retry', () => {
+    createTask(db, { id: 't-cap', title: 'Cap test', max_retries: 3 })
+    updateTask(db, 't-cap', {
+      status: 'failed',
+      failure_reason: 'worktree_branch_exists',
+      recovery_attempts: MAX_RECOVERY_ATTEMPTS,
+    })
+
+    const task = getTask(db, 't-cap')!
+    expect(shouldAttemptRecovery(task)).toBe(false)  // cap gate fires
+
+    // Caller (cli.ts) permanently fails the task when cap is hit
+    updateTask(db, 't-cap', {
+      status: 'failed',
+      retry_count: task.max_retries,
+      failure_reason: 'recovery_cap_reached',
+      failure_detail: `Auto-recovery attempted ${MAX_RECOVERY_ATTEMPTS} times without success`,
+    })
+
+    const updated = getTask(db, 't-cap')!
+    expect(updated.failure_reason).toBe('recovery_cap_reached')
+    expect(updated.retry_count).toBe(updated.max_retries)
+    // Verify it is excluded from the retry loop
+    const retriable = db.prepare(
+      "SELECT COUNT(*) AS cnt FROM tasks WHERE status = 'failed' AND retry_count < max_retries AND id = 't-cap'"
+    ).get() as { cnt: number }
+    expect(retriable.cnt).toBe(0)
+  })
+})

--- a/tests/spawner/spawn-error-capture.test.ts
+++ b/tests/spawner/spawn-error-capture.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { execSync } from 'child_process'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { createDb, closeDb } from '../../src/server/state/db.js'
+import { createTask, getTask, updateTask } from '../../src/server/state/tasks.js'
+import { registerAgent, getAgent, updateAgent } from '../../src/server/state/agents.js'
+import { handleSpawnWorker, handleGetSystemStatus, classifyWorktreeError } from '../../src/server/tools/orchestrator.js'
+import { classifyLaunchError } from '../../src/spawner/index.js'
+import type Database from 'better-sqlite3'
+
+// ---------------------------------------------------------------------------
+// classifyWorktreeError slug tests
+// ---------------------------------------------------------------------------
+
+describe('classifyWorktreeError', () => {
+  it('returns worktree_branch_exists when error mentions branch already exists', () => {
+    expect(classifyWorktreeError("fatal: branch 'mc/my-task' already exists")).toBe('worktree_branch_exists')
+  })
+
+  it('returns worktree_branch_exists case-insensitively', () => {
+    expect(classifyWorktreeError("fatal: Branch 'mc/foo' Already Exists")).toBe('worktree_branch_exists')
+  })
+
+  it('returns worktree_path_registered when error mentions already registered', () => {
+    expect(classifyWorktreeError("fatal: 'mc/foo' is already registered in the worktree list")).toBe('worktree_path_registered')
+  })
+
+  it('returns worktree_path_registered when error mentions checked out at', () => {
+    expect(classifyWorktreeError("fatal: 'mc/foo' is already checked out at '/tmp/mc-foo-abc'")).toBe('worktree_path_registered')
+  })
+
+  it('returns worktree_create_failed for generic errors', () => {
+    expect(classifyWorktreeError('fatal: not a git repository')).toBe('worktree_create_failed')
+    expect(classifyWorktreeError('ENOENT: no such file or directory')).toBe('worktree_create_failed')
+    expect(classifyWorktreeError('permission denied')).toBe('worktree_create_failed')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// classifyLaunchError slug tests
+// ---------------------------------------------------------------------------
+
+describe('classifyLaunchError', () => {
+  it('returns tmux_window_create_failed for prefixed tmux window errors', () => {
+    expect(classifyLaunchError('tmux_window_create_failed: Command failed')).toBe('tmux_window_create_failed')
+  })
+
+  it('returns tmux_session_create_failed for prefixed tmux session errors', () => {
+    expect(classifyLaunchError('tmux_session_create_failed: no server running')).toBe('tmux_session_create_failed')
+  })
+
+  it('returns settings_write_failed for prefixed settings errors', () => {
+    expect(classifyLaunchError('settings_write_failed: EACCES permission denied')).toBe('settings_write_failed')
+  })
+
+  it('returns settings_write_failed for unprefixed ENOENT errors', () => {
+    expect(classifyLaunchError("ENOENT: no such file or directory, open '/tmp/foo'")).toBe('settings_write_failed')
+  })
+
+  it('returns settings_write_failed for EACCES errors', () => {
+    expect(classifyLaunchError("EACCES: permission denied, open '/claude/.claude/settings.local.json'")).toBe('settings_write_failed')
+  })
+
+  it('returns agent_launch_failed for unrecognised errors', () => {
+    expect(classifyLaunchError('some random error')).toBe('agent_launch_failed')
+    expect(classifyLaunchError('')).toBe('agent_launch_failed')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleSpawnWorker: failure_reason and failure_detail persisted on task
+// ---------------------------------------------------------------------------
+
+describe('handleSpawnWorker failure_reason/failure_detail persistence', () => {
+  let db: Database.Database
+  let repoPath: string
+
+  beforeEach(() => {
+    db = createDb(':memory:')
+    repoPath = mkdtempSync(join(tmpdir(), 'mc-err-test-'))
+    execSync('git init', { cwd: repoPath })
+    execSync('git config user.email "test@test.com"', { cwd: repoPath })
+    execSync('git config user.name "Test"', { cwd: repoPath })
+    execSync('echo "init" > README.md && git add . && git commit -m "init"', { cwd: repoPath })
+  })
+
+  afterEach(() => {
+    closeDb(db)
+    rmSync(repoPath, { recursive: true, force: true })
+  })
+
+  it('stores worktree_branch_exists slug when branch already exists', async () => {
+    createTask(db, { id: 'task-branch-exists', title: 'Branch collision task' })
+    // Pre-create the branch so git worktree add collides
+    execSync(`git branch mc/task-branch-exists`, { cwd: repoPath })
+
+    const result = await handleSpawnWorker(db, 'task-branch-exists', 'w-t1', { cwd: repoPath })
+    // createWorktree handles stale branches internally — only a persistent
+    // collision would fail. We verify the slug path here via a direct DB write.
+    // Simulate what handleSpawnWorker does on worktree failure:
+    if (!result.ok) {
+      const task = getTask(db, 'task-branch-exists')!
+      expect(task.status).toBe('failed')
+      expect(task.failure_reason).toBeTruthy()
+      expect(task.failure_detail).toBeTruthy()
+    } else {
+      // createWorktree cleaned up the stale branch — verify worktree succeeded
+      const task = getTask(db, 'task-branch-exists')!
+      expect(task.status).toBe('in_progress')
+      if (task.worktree_path) rmSync(task.worktree_path, { recursive: true, force: true })
+    }
+  })
+
+  it('stores repo_path before worktree creation so retry loop can find it', async () => {
+    createTask(db, { id: 'task-repo-path', title: 'Repo path test' })
+    await handleSpawnWorker(db, 'task-repo-path', 'w-rp', { cwd: repoPath })
+    const task = getTask(db, 'task-repo-path')!
+    // repo_path is set early, regardless of success or failure
+    expect(task.repo_path).toBe(repoPath)
+    if (task.worktree_path) rmSync(task.worktree_path, { recursive: true, force: true })
+  })
+
+  it('sets failure_reason and failure_detail on task when worktree creation fails', () => {
+    // Inject failure directly via updateTask to simulate the path in handleSpawnWorker
+    createTask(db, { id: 'task-fail-slug', title: 'Slug test' })
+    updateTask(db, 'task-fail-slug', {
+      status: 'failed',
+      failure_reason: 'worktree_create_failed',
+      failure_detail: 'fatal: not a git repository',
+    })
+    const task = getTask(db, 'task-fail-slug')!
+    expect(task.failure_reason).toBe('worktree_create_failed')
+    expect(task.failure_detail).toBe('fatal: not a git repository')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// failure_reason/failure_detail appear in get_system_status output
+// ---------------------------------------------------------------------------
+
+describe('failure fields in system status', () => {
+  let db: Database.Database
+
+  beforeEach(() => { db = createDb(':memory:') })
+  afterEach(() => { closeDb(db) })
+
+  it('failure_reason and failure_detail appear on tasks in get_system_status', () => {
+    db.prepare(
+      "INSERT INTO tasks (id, title, status, failure_reason, failure_detail) VALUES ('t1', 'Task', 'failed', 'tmux_window_create_failed', 'no more room')"
+    ).run()
+    const status = handleGetSystemStatus(db, true)
+    const task = status.tasks.find(t => t.id === 't1')!
+    expect(task.failure_reason).toBe('tmux_window_create_failed')
+    expect(task.failure_detail).toBe('no more room')
+  })
+
+  it('failure_reason and failure_detail are null when no failure occurred', () => {
+    db.prepare(
+      "INSERT INTO tasks (id, title, status) VALUES ('t1', 'Task', 'in_progress')"
+    ).run()
+    const status = handleGetSystemStatus(db, true)
+    const task = status.tasks.find(t => t.id === 't1')!
+    expect(task.failure_reason).toBeNull()
+    expect(task.failure_detail).toBeNull()
+  })
+
+  it('failure fields appear on retriableTasks', () => {
+    db.prepare(
+      "INSERT INTO tasks (id, title, status, retry_count, max_retries, failure_reason, failure_detail) VALUES ('t1', 'Task', 'failed', 0, 3, 'agent_launch_failed', 'claude not found')"
+    ).run()
+    const status = handleGetSystemStatus(db, true)
+    expect(status.retriableTasks).toHaveLength(1)
+    expect(status.retriableTasks[0].failure_reason).toBe('agent_launch_failed')
+    expect(status.retriableTasks[0].failure_detail).toBe('claude not found')
+  })
+
+  it('failure_reason and failure_detail on agents are stored and retrievable', () => {
+    db.prepare(
+      "INSERT INTO tasks (id, title, status) VALUES ('t1', 'Task', 'failed')"
+    ).run()
+    registerAgent(db, { id: 'a1', task_id: 't1' })
+    updateAgent(db, 'a1', {
+      status: 'failed',
+      failure_reason: 'tmux_window_create_failed',
+      failure_detail: 'can\'t create window',
+    })
+    const agent = getAgent(db, 'a1')!
+    expect(agent.failure_reason).toBe('tmux_window_create_failed')
+    expect(agent.failure_detail).toBe("can't create window")
+    // Also verify it shows in status agents list
+    const status = handleGetSystemStatus(db, true)
+    const statusAgent = status.agents.find(a => a.id === 'a1')!
+    expect(statusAgent.failure_reason).toBe('tmux_window_create_failed')
+    expect(statusAgent.failure_detail).toBe("can't create window")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// retry_count increments on creation failure
+// ---------------------------------------------------------------------------
+
+describe('retry_count increments on environment creation failure', () => {
+  let db: Database.Database
+
+  beforeEach(() => { db = createDb(':memory:') })
+  afterEach(() => { closeDb(db) })
+
+  it('retry_count advances after each launch failure via the retry loop', () => {
+    // Simulate what the spawner watcher does when backend.launch() throws:
+    // task is marked failed with failure_reason, then the retry loop picks it up.
+    createTask(db, { id: 'task-rc', title: 'RC task', max_retries: 3 })
+    updateTask(db, 'task-rc', {
+      status: 'failed',
+      failure_reason: 'tmux_window_create_failed',
+      failure_detail: 'tmux: no space',
+      repo_path: '/tmp/fake-repo',
+    })
+
+    // Simulate the retry loop incrementing retry_count
+    const task = getTask(db, 'task-rc')!
+    expect(task.retry_count).toBe(0)
+    updateTask(db, 'task-rc', { retry_count: task.retry_count + 1, status: 'pending' })
+
+    const updated = getTask(db, 'task-rc')!
+    expect(updated.retry_count).toBe(1)
+    expect(updated.status).toBe('pending')
+  })
+
+  it('retry_count persists across the new retry_count after handleSpawnWorker failure', () => {
+    // Verify that the fixed code does NOT revert retry_count on handleSpawnWorker failure.
+    // When handleSpawnWorker fails during retry, status goes failed but retry_count stays incremented.
+    createTask(db, { id: 'task-norevert', title: 'No revert task', max_retries: 3 })
+    // Step 1: first spawn fails → task failed, retry_count=0
+    updateTask(db, 'task-norevert', { status: 'failed' })
+    // Step 2: retry loop increments retry_count to 1
+    updateTask(db, 'task-norevert', { retry_count: 1, status: 'pending' })
+    // Step 3: handleSpawnWorker fails again during retry → fixed code: only reset status, keep retry_count
+    updateTask(db, 'task-norevert', { status: 'failed' })  // no retry_count revert
+
+    const task = getTask(db, 'task-norevert')!
+    expect(task.retry_count).toBe(1)  // stayed at 1, not reverted to 0
+    expect(task.status).toBe('failed')
+  })
+
+  it('task with retry_count >= max_retries is not retriable', () => {
+    createTask(db, { id: 'task-exhausted', title: 'Exhausted task', max_retries: 3 })
+    updateTask(db, 'task-exhausted', { status: 'failed', retry_count: 3 })
+
+    const status = handleGetSystemStatus(db, true)
+    const retriable = status.retriableTasks.find(t => t.id === 'task-exhausted')
+    expect(retriable).toBeUndefined()
+  })
+
+  it('backend launch failure marks task failed so retry loop can process it', () => {
+    // This is the core bug fix: backend.launch() throwing must mark task failed
+    // so the retry loop (which only processes 'failed' tasks) picks it up.
+    createTask(db, { id: 'task-launch-fail', title: 'Launch fail task', max_retries: 3 })
+    registerAgent(db, { id: 'a-launch-fail', task_id: 'task-launch-fail' })
+    updateTask(db, 'task-launch-fail', { status: 'in_progress', agent_id: 'a-launch-fail' })
+
+    // Simulate what the fixed cli.ts catch block does when backend.launch() throws:
+    const failureReason = 'tmux_window_create_failed'
+    const failureDetail = 'tmux: can\'t create window: no more room'
+    updateAgent(db, 'a-launch-fail', { status: 'failed', failure_reason: failureReason, failure_detail: failureDetail })
+    updateTask(db, 'task-launch-fail', { status: 'failed', failure_reason: failureReason, failure_detail: failureDetail })
+    db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
+      'task-launch-fail', 'error', `${failureReason}: ${failureDetail}`
+    )
+
+    // Now the retry loop can see the task as retriable
+    const status = handleGetSystemStatus(db, true)
+    const retriable = status.retriableTasks.find(t => t.id === 'task-launch-fail')
+    expect(retriable).toBeDefined()
+    expect(retriable!.failure_reason).toBe('tmux_window_create_failed')
+    expect(retriable!.failure_detail).toBe(failureDetail)
+  })
+
+  it('failure_reason slug worktree_branch_exists is recorded on task', () => {
+    createTask(db, { id: 'task-wbe', title: 'Branch exists task' })
+    updateTask(db, 'task-wbe', {
+      status: 'failed',
+      failure_reason: 'worktree_branch_exists',
+      failure_detail: "fatal: branch 'mc/task-wbe' already exists",
+    })
+    const task = getTask(db, 'task-wbe')!
+    expect(task.failure_reason).toBe('worktree_branch_exists')
+    expect(task.failure_detail).toContain('already exists')
+  })
+
+  it('failure_reason slug worktree_path_registered is recorded on task', () => {
+    createTask(db, { id: 'task-wpr', title: 'Path registered task' })
+    updateTask(db, 'task-wpr', {
+      status: 'failed',
+      failure_reason: 'worktree_path_registered',
+      failure_detail: "fatal: 'mc/task-wpr' is already registered in the worktree list",
+    })
+    const task = getTask(db, 'task-wpr')!
+    expect(task.failure_reason).toBe('worktree_path_registered')
+    expect(task.failure_detail).toContain('already registered')
+  })
+
+  it('failure_reason slug tmux_window_create_failed is recorded on task and agent', () => {
+    createTask(db, { id: 'task-twcf', title: 'Tmux window fail task' })
+    registerAgent(db, { id: 'a-twcf', task_id: 'task-twcf' })
+    updateTask(db, 'task-twcf', {
+      status: 'failed',
+      failure_reason: 'tmux_window_create_failed',
+      failure_detail: 'tmux_window_create_failed: Command failed: tmux new-window',
+    })
+    updateAgent(db, 'a-twcf', {
+      status: 'failed',
+      failure_reason: 'tmux_window_create_failed',
+      failure_detail: 'tmux_window_create_failed: Command failed: tmux new-window',
+    })
+    expect(getTask(db, 'task-twcf')!.failure_reason).toBe('tmux_window_create_failed')
+    expect(getAgent(db, 'a-twcf')!.failure_reason).toBe('tmux_window_create_failed')
+  })
+
+  it('failure_reason slug agent_process_never_started is recorded on task', () => {
+    createTask(db, { id: 'task-anps', title: 'Never started task' })
+    updateTask(db, 'task-anps', {
+      status: 'failed',
+      failure_reason: 'agent_process_never_started',
+      failure_detail: 'agent process never started',
+    })
+    const task = getTask(db, 'task-anps')!
+    expect(task.failure_reason).toBe('agent_process_never_started')
+  })
+
+  it('failure_reason slug settings_write_failed is recorded on task and agent', () => {
+    createTask(db, { id: 'task-swf', title: 'Settings write fail task' })
+    registerAgent(db, { id: 'a-swf', task_id: 'task-swf' })
+    updateTask(db, 'task-swf', {
+      status: 'failed',
+      failure_reason: 'settings_write_failed',
+      failure_detail: 'EACCES: permission denied',
+    })
+    updateAgent(db, 'a-swf', {
+      status: 'failed',
+      failure_reason: 'settings_write_failed',
+      failure_detail: 'EACCES: permission denied',
+    })
+    expect(getTask(db, 'task-swf')!.failure_reason).toBe('settings_write_failed')
+    expect(getAgent(db, 'a-swf')!.failure_reason).toBe('settings_write_failed')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DB migration: failure_detail column exists on both tables
+// ---------------------------------------------------------------------------
+
+describe('DB migration: failure columns exist', () => {
+  let db: Database.Database
+
+  beforeEach(() => { db = createDb(':memory:') })
+  afterEach(() => { closeDb(db) })
+
+  it('tasks table has failure_detail column', () => {
+    const row = db.prepare("PRAGMA table_info(tasks)").all() as { name: string }[]
+    const cols = row.map(r => r.name)
+    expect(cols).toContain('failure_reason')
+    expect(cols).toContain('failure_detail')
+  })
+
+  it('agents table has failure_reason and failure_detail columns', () => {
+    const row = db.prepare("PRAGMA table_info(agents)").all() as { name: string }[]
+    const cols = row.map(r => r.name)
+    expect(cols).toContain('failure_reason')
+    expect(cols).toContain('failure_detail')
+  })
+})

--- a/tests/spawner/tmux-preflight.test.ts
+++ b/tests/spawner/tmux-preflight.test.ts
@@ -261,7 +261,7 @@ describe('spawnTmuxWorker — preflight reaping and window verification', () => 
 
   it('throws a structured error when the window does not exist after creation', () => {
     setupSpawnMocks({ windowExistsResult: false })
-    expect(() => spawnTmuxWorker(cfg)).toThrow(/window creation failed/)
+    expect(() => spawnTmuxWorker(cfg)).toThrow(/tmux_window_create_failed/)
   })
 
   it('includes the window name in the creation-failure error', () => {

--- a/tests/spawner/tmux-preflight.test.ts
+++ b/tests/spawner/tmux-preflight.test.ts
@@ -1,0 +1,477 @@
+/**
+ * Tests for pre-spawn stale-window reaping, post-creation window verification,
+ * and orphan-window reaping for mc-* windows belonging to terminal tasks.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { mockExecSync, mockSpawn, mockWriteFileSync, mockMkdirSync } = vi.hoisted(() => ({
+  mockExecSync: vi.fn(),
+  mockSpawn: vi.fn(() => ({ on: vi.fn(), unref: vi.fn() })),
+  mockWriteFileSync: vi.fn(),
+  mockMkdirSync: vi.fn(),
+}))
+
+vi.mock('child_process', () => ({
+  execSync: mockExecSync,
+  spawn: mockSpawn,
+}))
+
+vi.mock('fs', () => ({
+  writeFileSync: mockWriteFileSync,
+  mkdirSync: mockMkdirSync,
+  existsSync: vi.fn(() => false),
+  readFileSync: vi.fn(() => ''),
+  openSync: vi.fn(() => 1),
+}))
+
+import {
+  listTmuxWindows,
+  windowExists,
+  reapStaleWindows,
+  reapOrphanWindows,
+  spawnTmuxWorker,
+} from '../../src/spawner/tmux.js'
+import { createDb, closeDb } from '../../src/server/state/db.js'
+import { createTask, updateTask } from '../../src/server/state/tasks.js'
+import { registerAgent, updateAgent } from '../../src/server/state/agents.js'
+import type Database from 'better-sqlite3'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// listTmuxWindows
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('listTmuxWindows', () => {
+  beforeEach(() => { mockExecSync.mockReset() })
+
+  it('parses window list into id/name pairs', () => {
+    mockExecSync.mockReturnValueOnce('@1 bash\n@2 mc-w-task-1\n@3 mc-w-task-2-retry1\n')
+    const result = listTmuxWindows('multiclaude')
+    expect(result).toEqual([
+      { windowId: '@1', windowName: 'bash' },
+      { windowId: '@2', windowName: 'mc-w-task-1' },
+      { windowId: '@3', windowName: 'mc-w-task-2-retry1' },
+    ])
+  })
+
+  it('returns empty array when session has no windows', () => {
+    mockExecSync.mockReturnValueOnce('\n')
+    expect(listTmuxWindows('multiclaude')).toEqual([])
+  })
+
+  it('returns empty array when tmux throws', () => {
+    mockExecSync.mockImplementationOnce(() => { throw new Error('no server') })
+    expect(listTmuxWindows('multiclaude')).toEqual([])
+  })
+
+  it('filters out lines without a valid @NN id', () => {
+    mockExecSync.mockReturnValueOnce('bad-line\n@5 my-window\n')
+    const result = listTmuxWindows('multiclaude')
+    expect(result).toHaveLength(1)
+    expect(result[0].windowId).toBe('@5')
+  })
+
+  it('calls list-windows with the correct session name', () => {
+    mockExecSync.mockReturnValueOnce('')
+    listTmuxWindows('my-session')
+    const cmd = mockExecSync.mock.calls[0][0] as string
+    expect(cmd).toContain('list-windows')
+    expect(cmd).toContain('my-session')
+    expect(cmd).toContain('#{window_id}')
+    expect(cmd).toContain('#{window_name}')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// windowExists
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('windowExists', () => {
+  beforeEach(() => { mockExecSync.mockReset() })
+
+  it('returns true when display-message succeeds', () => {
+    mockExecSync.mockReturnValueOnce('')
+    expect(windowExists('@42')).toBe(true)
+  })
+
+  it('returns false when display-message throws (window gone)', () => {
+    mockExecSync.mockImplementationOnce(() => { throw new Error('no such window') })
+    expect(windowExists('@42')).toBe(false)
+  })
+
+  it('targets the @NN window ID with display-message', () => {
+    mockExecSync.mockReturnValueOnce('')
+    windowExists('@99')
+    const cmd = mockExecSync.mock.calls[0][0] as string
+    expect(cmd).toContain('display-message')
+    expect(cmd).toContain('@99')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// reapStaleWindows — pre-spawn reaping
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('reapStaleWindows', () => {
+  beforeEach(() => { mockExecSync.mockReset() })
+
+  it('kills windows whose name matches mc-w-{taskId} exactly', () => {
+    // list-windows returns one exact-match window
+    mockExecSync.mockReturnValueOnce('@2 mc-w-task-42\n')
+    // kill-window call
+    mockExecSync.mockReturnValueOnce(undefined)
+
+    reapStaleWindows('multiclaude', 'task-42')
+
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string)
+    const killCall = calls.find(c => c.includes('kill-window'))
+    expect(killCall).toBeDefined()
+    expect(killCall).toContain('@2')
+  })
+
+  it('kills windows whose name starts with mc-w-{taskId}- (retry windows)', () => {
+    mockExecSync.mockReturnValueOnce('@3 mc-w-task-42-retry1\n@4 mc-w-task-42-retry2\n')
+    mockExecSync.mockReturnValueOnce(undefined) // kill @3
+    mockExecSync.mockReturnValueOnce(undefined) // kill @4
+
+    reapStaleWindows('multiclaude', 'task-42')
+
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string)
+    const killCalls = calls.filter(c => c.includes('kill-window'))
+    expect(killCalls).toHaveLength(2)
+    expect(killCalls[0]).toContain('@3')
+    expect(killCalls[1]).toContain('@4')
+  })
+
+  it('does not kill windows for a different task with a similar prefix', () => {
+    // task-4 should NOT kill mc-w-task-42
+    mockExecSync.mockReturnValueOnce('@2 mc-w-task-42\n')
+
+    reapStaleWindows('multiclaude', 'task-4')
+
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string)
+    expect(calls.some(c => c.includes('kill-window'))).toBe(false)
+  })
+
+  it('does not kill non-mc windows', () => {
+    mockExecSync.mockReturnValueOnce('@1 bash\n@2 zsh\n')
+
+    reapStaleWindows('multiclaude', 'task-42')
+
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string)
+    expect(calls.some(c => c.includes('kill-window'))).toBe(false)
+  })
+
+  it('is a no-op when no windows match', () => {
+    mockExecSync.mockReturnValueOnce('@1 mc-w-task-99\n')
+
+    reapStaleWindows('multiclaude', 'task-42')
+
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string)
+    expect(calls.some(c => c.includes('kill-window'))).toBe(false)
+  })
+
+  it('kills by @NN window ID, not by window name', () => {
+    mockExecSync.mockReturnValueOnce('@7 mc-w-task-42\n')
+    mockExecSync.mockReturnValueOnce(undefined)
+
+    reapStaleWindows('multiclaude', 'task-42')
+
+    const killCall = mockExecSync.mock.calls.map(c => c[0] as string).find(c => c.includes('kill-window'))!
+    expect(killCall).toContain('@7')
+    expect(killCall).not.toContain('mc-w-task-42')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// spawnTmuxWorker — pre-spawn reaping + post-creation verification
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('spawnTmuxWorker — preflight reaping and window verification', () => {
+  const cfg = {
+    taskId: 'task-42',
+    taskTitle: 'Build the thing',
+    agentId: 'w-task-42',
+    worktreePath: '/tmp/wt-42',
+    mcpConfigPath: '/tmp/mcp.json',
+  }
+
+  beforeEach(() => {
+    mockExecSync.mockReset()
+    mockSpawn.mockReset()
+    mockWriteFileSync.mockReset()
+    mockMkdirSync.mockReset()
+    mockSpawn.mockReturnValue({ on: vi.fn(), unref: vi.fn() })
+    delete process.env.TMUX
+  })
+
+  afterEach(() => { delete process.env.TMUX })
+
+  function setupSpawnMocks({
+    listWindows = '',
+    windowId = '@42',
+    windowExistsResult = true,
+    pid = '9999\n',
+  } = {}) {
+    mockExecSync.mockReturnValueOnce(undefined)       // has-session
+    mockExecSync.mockReturnValueOnce(listWindows)     // list-windows (reapStaleWindows)
+    mockExecSync.mockReturnValueOnce(`${windowId}\n`) // new-window
+    if (windowExistsResult) {
+      mockExecSync.mockReturnValueOnce(undefined)     // windowExists → success
+    } else {
+      mockExecSync.mockImplementationOnce(() => { throw new Error('no such window') }) // windowExists → fail
+    }
+    mockExecSync.mockReturnValueOnce(pid)             // pane PID
+    mockExecSync.mockReturnValueOnce(undefined)       // send-keys
+  }
+
+  it('calls list-windows before new-window to reap stale windows', () => {
+    setupSpawnMocks()
+    spawnTmuxWorker(cfg)
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string)
+    const listIdx = calls.findIndex(c => c.includes('list-windows'))
+    const newWinIdx = calls.findIndex(c => c.includes('new-window'))
+    expect(listIdx).toBeGreaterThanOrEqual(0)
+    expect(newWinIdx).toBeGreaterThan(listIdx)
+  })
+
+  it('kills a stale window for this task before spawning a new one', () => {
+    // list-windows returns a stale window for the same task
+    mockExecSync.mockReturnValueOnce(undefined)                           // has-session
+    mockExecSync.mockReturnValueOnce('@5 mc-w-task-42\n')                 // list-windows
+    mockExecSync.mockReturnValueOnce(undefined)                           // kill-window @5
+    mockExecSync.mockReturnValueOnce('@42\n')                             // new-window
+    mockExecSync.mockReturnValueOnce(undefined)                           // windowExists
+    mockExecSync.mockReturnValueOnce('9999\n')                            // pane PID
+    mockExecSync.mockReturnValueOnce(undefined)                           // send-keys
+
+    spawnTmuxWorker(cfg)
+
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string)
+    const killCall = calls.find(c => c.includes('kill-window') && c.includes('@5'))
+    expect(killCall).toBeDefined()
+  })
+
+  it('calls windowExists after createTmuxWindow using the returned @NN id', () => {
+    setupSpawnMocks({ windowId: '@77' })
+    spawnTmuxWorker(cfg)
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string)
+    const existsCall = calls.find(c => c.includes('display-message') && c.includes('@77'))
+    expect(existsCall).toBeDefined()
+  })
+
+  it('throws a structured error when the window does not exist after creation', () => {
+    setupSpawnMocks({ windowExistsResult: false })
+    expect(() => spawnTmuxWorker(cfg)).toThrow(/window creation failed/)
+  })
+
+  it('includes the window name in the creation-failure error', () => {
+    setupSpawnMocks({ windowExistsResult: false })
+    expect(() => spawnTmuxWorker(cfg)).toThrow(/mc-w-task-42/)
+  })
+
+  it('does not call sendTmuxKeys when window verification fails', () => {
+    setupSpawnMocks({ windowExistsResult: false })
+    try { spawnTmuxWorker(cfg) } catch { /* expected */ }
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string)
+    expect(calls.some(c => c.includes('send-keys'))).toBe(false)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// reapOrphanWindows — cleanup of mc-* windows for terminal tasks
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('reapOrphanWindows', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    mockExecSync.mockReset()
+    db = createDb(':memory:')
+    delete process.env.TMUX
+  })
+
+  afterEach(() => {
+    closeDb(db)
+    delete process.env.TMUX
+  })
+
+  function mockListWindows(output: string) {
+    // ensureTmuxSession: has-session check
+    mockExecSync.mockReturnValueOnce(undefined)
+    // listTmuxWindows: list-windows
+    mockExecSync.mockReturnValueOnce(output)
+  }
+
+  it('kills mc-* windows whose task is in done state', () => {
+    createTask(db, { id: 't1', title: 'T1' })
+    updateTask(db, 't1', { status: 'done' })
+    registerAgent(db, { id: 'w-t1', task_id: 't1' })
+    updateAgent(db, 'w-t1', { tmux_pane: '@10' })
+
+    mockListWindows('@10 mc-w-t1\n')
+    const killWindow = vi.fn()
+
+    reapOrphanWindows(db, killWindow)
+
+    expect(killWindow).toHaveBeenCalledWith('@10')
+  })
+
+  it('kills mc-* windows whose task is in failed state', () => {
+    createTask(db, { id: 't1', title: 'T1' })
+    updateTask(db, 't1', { status: 'failed' })
+    registerAgent(db, { id: 'w-t1', task_id: 't1' })
+    updateAgent(db, 'w-t1', { tmux_pane: '@11' })
+
+    mockListWindows('@11 mc-w-t1\n')
+    const killWindow = vi.fn()
+
+    reapOrphanWindows(db, killWindow)
+
+    expect(killWindow).toHaveBeenCalledWith('@11')
+  })
+
+  it('kills mc-* windows whose task is in cancelled state', () => {
+    createTask(db, { id: 't1', title: 'T1' })
+    updateTask(db, 't1', { status: 'cancelled' })
+    registerAgent(db, { id: 'w-t1', task_id: 't1' })
+    updateAgent(db, 'w-t1', { tmux_pane: '@12' })
+
+    mockListWindows('@12 mc-w-t1\n')
+    const killWindow = vi.fn()
+
+    reapOrphanWindows(db, killWindow)
+
+    expect(killWindow).toHaveBeenCalledWith('@12')
+  })
+
+  it('does NOT kill mc-* windows whose task is in_progress', () => {
+    createTask(db, { id: 't1', title: 'T1' })
+    updateTask(db, 't1', { status: 'in_progress' })
+    registerAgent(db, { id: 'w-t1', task_id: 't1' })
+    updateAgent(db, 'w-t1', { tmux_pane: '@13' })
+
+    mockListWindows('@13 mc-w-t1\n')
+    const killWindow = vi.fn()
+
+    reapOrphanWindows(db, killWindow)
+
+    expect(killWindow).not.toHaveBeenCalled()
+  })
+
+  it('does NOT kill mc-* windows whose task is pending', () => {
+    createTask(db, { id: 't1', title: 'T1' })
+    // status defaults to 'pending'
+    registerAgent(db, { id: 'w-t1', task_id: 't1' })
+    updateAgent(db, 'w-t1', { tmux_pane: '@14' })
+
+    mockListWindows('@14 mc-w-t1\n')
+    const killWindow = vi.fn()
+
+    reapOrphanWindows(db, killWindow)
+
+    expect(killWindow).not.toHaveBeenCalled()
+  })
+
+  it('kills mc-* windows with no matching agent record (fully orphaned)', () => {
+    // No agent row for @15
+    mockListWindows('@15 mc-w-ghost\n')
+    const killWindow = vi.fn()
+
+    reapOrphanWindows(db, killWindow)
+
+    expect(killWindow).toHaveBeenCalledWith('@15')
+  })
+
+  it('kills mc-* windows whose agent has no task_id', () => {
+    registerAgent(db, { id: 'w-no-task' }) // no task_id
+    updateAgent(db, 'w-no-task', { tmux_pane: '@16' })
+
+    mockListWindows('@16 mc-w-no-task\n')
+    const killWindow = vi.fn()
+
+    reapOrphanWindows(db, killWindow)
+
+    expect(killWindow).toHaveBeenCalledWith('@16')
+  })
+
+  it('never kills windows that do not match the mc- prefix', () => {
+    mockListWindows('@1 bash\n@2 zsh\n@3 my-window\n')
+    const killWindow = vi.fn()
+
+    reapOrphanWindows(db, killWindow)
+
+    expect(killWindow).not.toHaveBeenCalled()
+  })
+
+  it('leaves non-MultiClaude windows untouched even when mc-* windows are reaped', () => {
+    createTask(db, { id: 't1', title: 'T1' })
+    updateTask(db, 't1', { status: 'done' })
+    registerAgent(db, { id: 'w-t1', task_id: 't1' })
+    updateAgent(db, 'w-t1', { tmux_pane: '@20' })
+
+    // Mix of mc- and non-mc windows
+    mockListWindows('@1 bash\n@2 my-project\n@20 mc-w-t1\n')
+    const killWindow = vi.fn()
+
+    reapOrphanWindows(db, killWindow)
+
+    // Only the mc- window should be killed
+    expect(killWindow).toHaveBeenCalledTimes(1)
+    expect(killWindow).toHaveBeenCalledWith('@20')
+  })
+
+  it('reaps multiple orphan windows in one pass', () => {
+    createTask(db, { id: 't1', title: 'T1' })
+    updateTask(db, 't1', { status: 'done' })
+    registerAgent(db, { id: 'w-t1', task_id: 't1' })
+    updateAgent(db, 'w-t1', { tmux_pane: '@30' })
+
+    createTask(db, { id: 't2', title: 'T2' })
+    updateTask(db, 't2', { status: 'failed' })
+    registerAgent(db, { id: 'w-t2', task_id: 't2' })
+    updateAgent(db, 'w-t2', { tmux_pane: '@31' })
+
+    // Plus a fully orphaned window with no agent record
+    mockListWindows('@30 mc-w-t1\n@31 mc-w-t2\n@32 mc-w-ghost\n')
+    const killWindow = vi.fn()
+
+    reapOrphanWindows(db, killWindow)
+
+    expect(killWindow).toHaveBeenCalledTimes(3)
+    expect(killWindow).toHaveBeenCalledWith('@30')
+    expect(killWindow).toHaveBeenCalledWith('@31')
+    expect(killWindow).toHaveBeenCalledWith('@32')
+  })
+
+  it('skips live tasks while reaping dead ones in the same pass', () => {
+    createTask(db, { id: 'live', title: 'Live' })
+    updateTask(db, 'live', { status: 'in_progress' })
+    registerAgent(db, { id: 'w-live', task_id: 'live' })
+    updateAgent(db, 'w-live', { tmux_pane: '@40' })
+
+    createTask(db, { id: 'dead', title: 'Dead' })
+    updateTask(db, 'dead', { status: 'done' })
+    registerAgent(db, { id: 'w-dead', task_id: 'dead' })
+    updateAgent(db, 'w-dead', { tmux_pane: '@41' })
+
+    mockListWindows('@40 mc-w-live\n@41 mc-w-dead\n')
+    const killWindow = vi.fn()
+
+    reapOrphanWindows(db, killWindow)
+
+    expect(killWindow).toHaveBeenCalledTimes(1)
+    expect(killWindow).toHaveBeenCalledWith('@41')
+    expect(killWindow).not.toHaveBeenCalledWith('@40')
+  })
+
+  it('is a no-op when tmux is unavailable (ensureTmuxSession throws)', () => {
+    delete process.env.TMUX
+    mockExecSync.mockImplementationOnce(() => { throw new Error('no tmux') }) // has-session fails
+    // new-session also fails (for non-tmux path, has-session throws means we try new-session)
+    mockExecSync.mockImplementationOnce(() => { throw new Error('no tmux') })
+
+    const killWindow = vi.fn()
+    expect(() => reapOrphanWindows(db, killWindow)).not.toThrow()
+    expect(killWindow).not.toHaveBeenCalled()
+  })
+})

--- a/tests/spawner/tmux.test.ts
+++ b/tests/spawner/tmux.test.ts
@@ -110,7 +110,7 @@ describe('createTmuxWindow', () => {
 
   it('throws when tmux returns an empty window ID', () => {
     mockExecSync.mockReturnValueOnce('\n')
-    expect(() => createTmuxWindow('sess', 'mc-w-task', '/path')).toThrow(/Failed to get window ID/)
+    expect(() => createTmuxWindow('sess', 'mc-w-task', '/path')).toThrow(/tmux_window_create_failed/)
   })
 })
 

--- a/tests/spawner/tmux.test.ts
+++ b/tests/spawner/tmux.test.ts
@@ -283,21 +283,17 @@ describe('spawnTmuxWorker', () => {
     mcpConfigPath: '/tmp/mcp.json',
   }
 
-  // Helper: sets up the standard 6-call mock sequence (not-in-tmux path)
+  // Helper: sets up the standard 4-call mock sequence (not-in-tmux path)
   // 1. has-session (ensureTmuxSession)
-  // 2. list-windows (reapStaleWindows → listTmuxWindows → returns empty)
-  // 3. new-window -P -F #{window_id} (createTmuxWindow → returns windowId)
-  // 4. display-message '' (windowExists → succeeds)
-  // 5. display-message pane_pid (getTmuxPanePid)
-  // 6. send-keys (sendTmuxKeys)
+  // 2. new-window -P -F #{window_id} (createTmuxWindow → returns windowId)
+  // 3. display-message pane_pid (getTmuxPanePid)
+  // 4. send-keys (sendTmuxKeys)
   function setupDefaultMocks({ windowId = '@42', pid = '9999\n' } = {}) {
     mockExecSync.mockReset()
-    mockExecSync.mockReturnValueOnce(undefined)       // has-session succeeds
-    mockExecSync.mockReturnValueOnce('')              // list-windows (reapStaleWindows) → empty
+    mockExecSync.mockReturnValueOnce(undefined)     // has-session succeeds
     mockExecSync.mockReturnValueOnce(`${windowId}\n`) // new-window returns @NN
-    mockExecSync.mockReturnValueOnce(undefined)       // windowExists succeeds
-    mockExecSync.mockReturnValueOnce(pid)             // pane PID
-    mockExecSync.mockReturnValueOnce(undefined)       // send-keys
+    mockExecSync.mockReturnValueOnce(pid)            // pane PID
+    mockExecSync.mockReturnValueOnce(undefined)      // send-keys
   }
 
   beforeEach(() => {
@@ -335,9 +331,7 @@ describe('spawnTmuxWorker', () => {
     for (const agentId of ['w-task-1', 'w-task-1-retry1', 'w-task-1-retry2']) {
       mockExecSync.mockReset()
       mockExecSync.mockReturnValueOnce(undefined)    // has-session
-      mockExecSync.mockReturnValueOnce('')           // list-windows (reapStaleWindows)
-      mockExecSync.mockReturnValueOnce('@99\n')      // new-window
-      mockExecSync.mockReturnValueOnce(undefined)    // windowExists
+      mockExecSync.mockReturnValueOnce('@99\n')       // new-window
       mockExecSync.mockReturnValueOnce('1234\n')     // pane PID
       mockExecSync.mockReturnValueOnce(undefined)    // send-keys
       mockSpawn.mockReturnValue({ on: vi.fn(), unref: vi.fn() })
@@ -362,9 +356,7 @@ describe('spawnTmuxWorker', () => {
   it('pid is undefined when getTmuxPanePid fails', () => {
     mockExecSync.mockReset()
     mockExecSync.mockReturnValueOnce(undefined)                              // has-session
-    mockExecSync.mockReturnValueOnce('')                                     // list-windows (reapStaleWindows)
     mockExecSync.mockReturnValueOnce('@42\n')                                // new-window
-    mockExecSync.mockReturnValueOnce(undefined)                              // windowExists
     mockExecSync.mockImplementationOnce(() => { throw new Error('nopid') }) // pane PID fails
     mockExecSync.mockReturnValueOnce(undefined)                              // send-keys
 

--- a/tests/spawner/tmux.test.ts
+++ b/tests/spawner/tmux.test.ts
@@ -283,17 +283,21 @@ describe('spawnTmuxWorker', () => {
     mcpConfigPath: '/tmp/mcp.json',
   }
 
-  // Helper: sets up the standard 4-call mock sequence (not-in-tmux path)
+  // Helper: sets up the standard 6-call mock sequence (not-in-tmux path)
   // 1. has-session (ensureTmuxSession)
-  // 2. new-window -P -F #{window_id} (createTmuxWindow → returns windowId)
-  // 3. display-message pane_pid (getTmuxPanePid)
-  // 4. send-keys (sendTmuxKeys)
+  // 2. list-windows (reapStaleWindows → listTmuxWindows)
+  // 3. new-window -P -F #{window_id} (createTmuxWindow → returns windowId)
+  // 4. display-message '' (windowExists check)
+  // 5. display-message pane_pid (getTmuxPanePid)
+  // 6. send-keys (sendTmuxKeys)
   function setupDefaultMocks({ windowId = '@42', pid = '9999\n' } = {}) {
     mockExecSync.mockReset()
-    mockExecSync.mockReturnValueOnce(undefined)     // has-session succeeds
+    mockExecSync.mockReturnValueOnce(undefined)        // has-session succeeds
+    mockExecSync.mockReturnValueOnce('')               // list-windows (no stale windows)
     mockExecSync.mockReturnValueOnce(`${windowId}\n`) // new-window returns @NN
-    mockExecSync.mockReturnValueOnce(pid)            // pane PID
-    mockExecSync.mockReturnValueOnce(undefined)      // send-keys
+    mockExecSync.mockReturnValueOnce(undefined)        // windowExists check
+    mockExecSync.mockReturnValueOnce(pid)              // pane PID
+    mockExecSync.mockReturnValueOnce(undefined)        // send-keys
   }
 
   beforeEach(() => {
@@ -331,7 +335,9 @@ describe('spawnTmuxWorker', () => {
     for (const agentId of ['w-task-1', 'w-task-1-retry1', 'w-task-1-retry2']) {
       mockExecSync.mockReset()
       mockExecSync.mockReturnValueOnce(undefined)    // has-session
+      mockExecSync.mockReturnValueOnce('')           // list-windows
       mockExecSync.mockReturnValueOnce('@99\n')       // new-window
+      mockExecSync.mockReturnValueOnce(undefined)    // windowExists check
       mockExecSync.mockReturnValueOnce('1234\n')     // pane PID
       mockExecSync.mockReturnValueOnce(undefined)    // send-keys
       mockSpawn.mockReturnValue({ on: vi.fn(), unref: vi.fn() })
@@ -356,7 +362,9 @@ describe('spawnTmuxWorker', () => {
   it('pid is undefined when getTmuxPanePid fails', () => {
     mockExecSync.mockReset()
     mockExecSync.mockReturnValueOnce(undefined)                              // has-session
+    mockExecSync.mockReturnValueOnce('')                                     // list-windows
     mockExecSync.mockReturnValueOnce('@42\n')                                // new-window
+    mockExecSync.mockReturnValueOnce(undefined)                              // windowExists check
     mockExecSync.mockImplementationOnce(() => { throw new Error('nopid') }) // pane PID fails
     mockExecSync.mockReturnValueOnce(undefined)                              // send-keys
 

--- a/tests/spawner/tmux.test.ts
+++ b/tests/spawner/tmux.test.ts
@@ -283,17 +283,21 @@ describe('spawnTmuxWorker', () => {
     mcpConfigPath: '/tmp/mcp.json',
   }
 
-  // Helper: sets up the standard 4-call mock sequence (not-in-tmux path)
+  // Helper: sets up the standard 6-call mock sequence (not-in-tmux path)
   // 1. has-session (ensureTmuxSession)
-  // 2. new-window -P -F #{window_id} (createTmuxWindow → returns windowId)
-  // 3. display-message pane_pid (getTmuxPanePid)
-  // 4. send-keys (sendTmuxKeys)
+  // 2. list-windows (reapStaleWindows → listTmuxWindows → returns empty)
+  // 3. new-window -P -F #{window_id} (createTmuxWindow → returns windowId)
+  // 4. display-message '' (windowExists → succeeds)
+  // 5. display-message pane_pid (getTmuxPanePid)
+  // 6. send-keys (sendTmuxKeys)
   function setupDefaultMocks({ windowId = '@42', pid = '9999\n' } = {}) {
     mockExecSync.mockReset()
-    mockExecSync.mockReturnValueOnce(undefined)     // has-session succeeds
+    mockExecSync.mockReturnValueOnce(undefined)       // has-session succeeds
+    mockExecSync.mockReturnValueOnce('')              // list-windows (reapStaleWindows) → empty
     mockExecSync.mockReturnValueOnce(`${windowId}\n`) // new-window returns @NN
-    mockExecSync.mockReturnValueOnce(pid)            // pane PID
-    mockExecSync.mockReturnValueOnce(undefined)      // send-keys
+    mockExecSync.mockReturnValueOnce(undefined)       // windowExists succeeds
+    mockExecSync.mockReturnValueOnce(pid)             // pane PID
+    mockExecSync.mockReturnValueOnce(undefined)       // send-keys
   }
 
   beforeEach(() => {
@@ -331,7 +335,9 @@ describe('spawnTmuxWorker', () => {
     for (const agentId of ['w-task-1', 'w-task-1-retry1', 'w-task-1-retry2']) {
       mockExecSync.mockReset()
       mockExecSync.mockReturnValueOnce(undefined)    // has-session
-      mockExecSync.mockReturnValueOnce('@99\n')       // new-window
+      mockExecSync.mockReturnValueOnce('')           // list-windows (reapStaleWindows)
+      mockExecSync.mockReturnValueOnce('@99\n')      // new-window
+      mockExecSync.mockReturnValueOnce(undefined)    // windowExists
       mockExecSync.mockReturnValueOnce('1234\n')     // pane PID
       mockExecSync.mockReturnValueOnce(undefined)    // send-keys
       mockSpawn.mockReturnValue({ on: vi.fn(), unref: vi.fn() })
@@ -356,7 +362,9 @@ describe('spawnTmuxWorker', () => {
   it('pid is undefined when getTmuxPanePid fails', () => {
     mockExecSync.mockReset()
     mockExecSync.mockReturnValueOnce(undefined)                              // has-session
+    mockExecSync.mockReturnValueOnce('')                                     // list-windows (reapStaleWindows)
     mockExecSync.mockReturnValueOnce('@42\n')                                // new-window
+    mockExecSync.mockReturnValueOnce(undefined)                              // windowExists
     mockExecSync.mockImplementationOnce(() => { throw new Error('nopid') }) // pane PID fails
     mockExecSync.mockReturnValueOnce(undefined)                              // send-keys
 

--- a/tests/tools/merge-failure-attribution.test.ts
+++ b/tests/tools/merge-failure-attribution.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for merge failure attribution fix (#101):
+ * - Cleanup errors must not be reported as "merge failed"
+ * - Ancestor check before marking failed (secondary defense)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const {
+  mockEnsureIntegrationBranch,
+  mockMergeWorktreeBranch,
+  mockIsMergedInto,
+  mockRemoveWorktree,
+  mockKillTmuxWindow,
+} = vi.hoisted(() => ({
+  mockEnsureIntegrationBranch: vi.fn<() => Promise<void>>(),
+  mockMergeWorktreeBranch: vi.fn<() => Promise<void>>(),
+  mockIsMergedInto: vi.fn<() => Promise<boolean>>(),
+  mockRemoveWorktree: vi.fn<() => Promise<void>>(),
+  mockKillTmuxWindow: vi.fn(),
+}))
+
+vi.mock('../../src/git/merge.js', () => ({
+  ensureIntegrationBranch: mockEnsureIntegrationBranch,
+  mergeWorktreeBranch: mockMergeWorktreeBranch,
+  isMergedInto: mockIsMergedInto,
+  MergeConflictError: class MergeConflictError extends Error {
+    taskBranch: string; integBranch: string; conflictedFiles: string[]
+    constructor(taskBranch: string, integBranch: string, conflictedFiles: string[]) {
+      super(`Merge conflict: ${taskBranch} → ${integBranch}`)
+      this.name = 'MergeConflictError'
+      this.taskBranch = taskBranch
+      this.integBranch = integBranch
+      this.conflictedFiles = conflictedFiles
+    }
+  },
+}))
+
+vi.mock('../../src/git/worktree.js', () => ({
+  removeWorktree: mockRemoveWorktree,
+}))
+
+vi.mock('../../src/spawner/tmux.js', () => ({
+  killTmuxWindow: mockKillTmuxWindow,
+  captureTmuxPane: vi.fn(() => ''),
+  spawnTmuxWorker: vi.fn(),
+  ensureTmuxSession: vi.fn(() => 'multiclaude'),
+  createTmuxWindow: vi.fn(() => '@1'),
+}))
+
+import { createDb, closeDb } from '../../src/server/state/db.js'
+import { createTask, updateTask, getTask } from '../../src/server/state/tasks.js'
+import { handleReportDone } from '../../src/server/tools/worker.js'
+import type Database from 'better-sqlite3'
+
+function setupTask(db: Database.Database, id = 't1') {
+  createTask(db, { id, title: 'Test task' })
+  updateTask(db, id, {
+    status: 'in_progress',
+    worktree_path: '/tmp/fake-worktree',
+    branch: 'feature/test',
+    head_sha: null, // skip empty-branch check; we test merge behavior only
+    repo_path: '/fake/repo',
+  })
+}
+
+describe('handleReportDone — merge failure attribution', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = createDb(':memory:')
+    mockEnsureIntegrationBranch.mockReset().mockResolvedValue(undefined)
+    mockMergeWorktreeBranch.mockReset().mockResolvedValue(undefined)
+    mockIsMergedInto.mockReset().mockResolvedValue(false)
+    mockRemoveWorktree.mockReset().mockResolvedValue(undefined)
+    mockKillTmuxWindow.mockReset()
+  })
+
+  afterEach(() => { closeDb(db) })
+
+  describe('primary fix: cleanup error outside merge try/catch', () => {
+    it('marks task done when merge succeeds but removeWorktree throws', async () => {
+      setupTask(db)
+      mockRemoveWorktree.mockRejectedValue(
+        new Error('cannot use simple-git on a directory that does not exist')
+      )
+
+      await handleReportDone(db, 't1', 'feature done')
+
+      const task = getTask(db, 't1')
+      expect(task?.status).toBe('done')
+      expect(task?.failure_reason).toBeNull()
+    })
+
+    it('records cleanup error as a warn log with post_merge_cleanup_failed reason', async () => {
+      setupTask(db)
+      mockRemoveWorktree.mockRejectedValue(new Error('worktree already removed'))
+
+      await handleReportDone(db, 't1', 'done')
+
+      const warnLog = db.prepare(
+        "SELECT message FROM logs WHERE task_id = 't1' AND level = 'warn'"
+      ).get() as { message: string } | undefined
+      expect(warnLog?.message).toContain('post_merge_cleanup_failed')
+      expect(warnLog?.message).toContain('worktree already removed')
+    })
+
+    it('does NOT write an error log when only cleanup fails', async () => {
+      setupTask(db)
+      mockRemoveWorktree.mockRejectedValue(new Error('cleanup error'))
+
+      await handleReportDone(db, 't1', 'done')
+
+      const errorLog = db.prepare(
+        "SELECT message FROM logs WHERE task_id = 't1' AND level = 'error'"
+      ).get()
+      expect(errorLog).toBeUndefined()
+    })
+  })
+
+  describe('genuine merge failure', () => {
+    it('marks task failed with failure_reason "merge failed" when merge does not land', async () => {
+      setupTask(db)
+      mockMergeWorktreeBranch.mockRejectedValue(new Error('git merge returned non-zero exit'))
+      mockIsMergedInto.mockResolvedValue(false)
+
+      await handleReportDone(db, 't1', 'done')
+
+      const task = getTask(db, 't1')
+      expect(task?.status).toBe('failed')
+      expect(task?.failure_reason).toBe('merge failed')
+    })
+
+    it('writes an error log on genuine merge failure', async () => {
+      setupTask(db)
+      mockMergeWorktreeBranch.mockRejectedValue(new Error('git merge failed'))
+      mockIsMergedInto.mockResolvedValue(false)
+
+      await handleReportDone(db, 't1', 'done')
+
+      const errorLog = db.prepare(
+        "SELECT message FROM logs WHERE task_id = 't1' AND level = 'error'"
+      ).get() as { message: string } | undefined
+      expect(errorLog?.message).toContain('Merge failed')
+      expect(errorLog?.message).toContain('feature/test')
+    })
+  })
+
+  describe('secondary defense: ancestor check before marking failed', () => {
+    it('marks task done when mergeWorktreeBranch throws but branch is already an ancestor', async () => {
+      setupTask(db)
+      mockMergeWorktreeBranch.mockRejectedValue(new Error('push to origin failed'))
+      mockIsMergedInto.mockResolvedValue(true)
+
+      await handleReportDone(db, 't1', 'done')
+
+      const task = getTask(db, 't1')
+      expect(task?.status).toBe('done')
+      expect(task?.failure_reason).toBeNull()
+    })
+
+    it('records the post-merge error as a warn when ancestor check passes', async () => {
+      setupTask(db)
+      mockMergeWorktreeBranch.mockRejectedValue(new Error('post-merge verification error'))
+      mockIsMergedInto.mockResolvedValue(true)
+
+      await handleReportDone(db, 't1', 'done')
+
+      const warnLog = db.prepare(
+        "SELECT message FROM logs WHERE task_id = 't1' AND level = 'warn'"
+      ).get() as { message: string } | undefined
+      expect(warnLog?.message).toContain('post_merge_cleanup_failed')
+      expect(warnLog?.message).toContain('post-merge verification error')
+    })
+
+    it('marks task failed when mergeWorktreeBranch throws AND ancestor check returns false', async () => {
+      setupTask(db)
+      mockMergeWorktreeBranch.mockRejectedValue(new Error('merge conflict'))
+      mockIsMergedInto.mockResolvedValue(false)
+
+      await handleReportDone(db, 't1', 'done')
+
+      const task = getTask(db, 't1')
+      expect(task?.status).toBe('failed')
+      expect(task?.failure_reason).toBe('merge failed')
+    })
+
+    it('falls back to "not landed" when isMergedInto itself throws', async () => {
+      setupTask(db)
+      mockMergeWorktreeBranch.mockRejectedValue(new Error('merge error'))
+      mockIsMergedInto.mockRejectedValue(new Error('git unavailable'))
+
+      await handleReportDone(db, 't1', 'done')
+
+      const task = getTask(db, 't1')
+      expect(task?.status).toBe('failed')
+      expect(task?.failure_reason).toBe('merge failed')
+    })
+  })
+})

--- a/tests/tools/recover-task.test.ts
+++ b/tests/tools/recover-task.test.ts
@@ -1,0 +1,485 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { mockKillTmuxWindow, mockReapStaleWindows, mockEnsureTmuxSession } = vi.hoisted(() => ({
+  mockKillTmuxWindow: vi.fn(),
+  mockReapStaleWindows: vi.fn(),
+  mockEnsureTmuxSession: vi.fn(() => 'multiclaude'),
+}))
+
+vi.mock('../../src/spawner/tmux.js', () => ({
+  killTmuxWindow: mockKillTmuxWindow,
+  reapStaleWindows: mockReapStaleWindows,
+  ensureTmuxSession: mockEnsureTmuxSession,
+  captureTmuxPane: vi.fn(() => ''),
+  spawnTmuxWorker: vi.fn(),
+  createTmuxWindow: vi.fn(() => '@1'),
+  getTmuxPanePid: vi.fn(() => undefined),
+  sendTmuxKeys: vi.fn(),
+  writeLaunchScript: vi.fn(() => '/tmp/worker-launch.sh'),
+  sendToPane: vi.fn(() => ({ sent: true, enterRetries: 0 })),
+  capturePaneText: vi.fn(() => ''),
+  classifyComposerState: vi.fn(() => 'empty'),
+  listTmuxWindows: vi.fn(() => []),
+  reapOrphanWindows: vi.fn(),
+  windowExists: vi.fn(() => true),
+  getChildProcessPid: vi.fn(() => undefined),
+  stripAnsiDim: vi.fn((s: string) => s),
+  stripBoxDrawing: vi.fn((s: string) => s),
+  cleanComposerLine: vi.fn((s: string) => s),
+}))
+
+import { createDb, closeDb } from '../../src/server/state/db.js'
+import { createTask, updateTask, getTask } from '../../src/server/state/tasks.js'
+import { registerAgent, updateAgent, getAgent } from '../../src/server/state/agents.js'
+import { handleRecoverTask } from '../../src/server/tools/orchestrator.js'
+import { execSync } from 'child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type Database from 'better-sqlite3'
+
+// Strip worktree isolation vars that interfere when the test runs inside
+// a MultiClaude worktree. Cleared from process.env so simpleGit (used by
+// preflightReconcile) also sees the clean environment.
+const savedGitEnv = {
+  GIT_DIR: process.env.GIT_DIR,
+  GIT_WORK_TREE: process.env.GIT_WORK_TREE,
+  GIT_CEILING_DIRECTORIES: process.env.GIT_CEILING_DIRECTORIES,
+}
+delete process.env.GIT_DIR
+delete process.env.GIT_WORK_TREE
+delete process.env.GIT_CEILING_DIRECTORIES
+
+const cleanEnv = { ...process.env }
+
+function git(cmd: string, cwd: string): string {
+  return execSync(cmd, { cwd, env: cleanEnv, encoding: 'utf8' })
+}
+
+describe('recover_task', () => {
+  let db: Database.Database
+  let repoPath: string
+
+  beforeEach(() => {
+    db = createDb(':memory:')
+    repoPath = mkdtempSync(join(tmpdir(), 'mc-recover-test-'))
+    git('git init', repoPath)
+    git('git config user.email "test@test.com"', repoPath)
+    git('git config user.name "Test"', repoPath)
+    git('echo "init" > README.md && git add . && git commit --no-gpg-sign -m "init"', repoPath)
+    mockKillTmuxWindow.mockReset()
+    mockReapStaleWindows.mockReset()
+    mockEnsureTmuxSession.mockReset()
+    mockEnsureTmuxSession.mockReturnValue('multiclaude')
+  })
+
+  afterEach(() => {
+    closeDb(db)
+    try { git('git worktree prune', repoPath) } catch {}
+    rmSync(repoPath, { recursive: true, force: true })
+  })
+
+  // --- Verdict: unrecoverable ---
+
+  describe('unrecoverable verdicts', () => {
+    it('returns unrecoverable when task does not exist', async () => {
+      const result = await handleRecoverTask(db, 'nonexistent')
+      expect(result.verdict).toBe('unrecoverable')
+      expect(result.reason).toContain('not found')
+      expect(result.actions).toEqual([])
+    })
+
+    it('returns unrecoverable when task is done', async () => {
+      createTask(db, { id: 't1', title: 'Done task' })
+      updateTask(db, 't1', { status: 'done' })
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.verdict).toBe('unrecoverable')
+      expect(result.reason).toContain('done')
+    })
+
+    it('returns unrecoverable when task is cancelled', async () => {
+      createTask(db, { id: 't1', title: 'Cancelled task' })
+      updateTask(db, 't1', { status: 'cancelled' })
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.verdict).toBe('unrecoverable')
+      expect(result.reason).toContain('cancelled')
+    })
+
+    it('returns unrecoverable when git reconciliation fails (bad repo path)', async () => {
+      createTask(db, { id: 't1', title: 'Bad repo' })
+      updateTask(db, 't1', { status: 'failed', failure_reason: 'worktree_branch_exists', repo_path: '/nonexistent/path', branch: 'mc/t1' })
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.verdict).toBe('unrecoverable')
+      expect(result.reason).toContain('Git reconciliation failed')
+      expect(result.actions.some(a => !a.success)).toBe(true)
+      // Task should NOT be reset when unrecoverable
+      const task = getTask(db, 't1')!
+      expect(task.status).toBe('failed')
+    })
+  })
+
+  // --- Verdict: needs_human ---
+
+  describe('needs_human verdicts', () => {
+    it('returns needs_human when task is in_progress', async () => {
+      createTask(db, { id: 't1', title: 'Active task' })
+      updateTask(db, 't1', { status: 'in_progress' })
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.verdict).toBe('needs_human')
+      expect(result.reason).toContain('in_progress')
+    })
+
+    it('returns needs_human for tmux_session_create_failed (resets task)', async () => {
+      createTask(db, { id: 't1', title: 'Tmux session fail' })
+      updateTask(db, 't1', { status: 'failed', failure_reason: 'tmux_session_create_failed' })
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.verdict).toBe('needs_human')
+      expect(result.reason).toContain('tmux')
+      expect(result.actions.some(a => a.action === 'diagnose')).toBe(true)
+      expect(result.actions.some(a => a.action === 'reset_task')).toBe(true)
+      const task = getTask(db, 't1')!
+      expect(task.status).toBe('pending')
+      expect(task.failure_reason).toBeNull()
+    })
+
+    it('returns needs_human for settings_write_failed (resets task)', async () => {
+      createTask(db, { id: 't1', title: 'Settings fail' })
+      updateTask(db, 't1', { status: 'failed', failure_reason: 'settings_write_failed' })
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.verdict).toBe('needs_human')
+      expect(result.reason).toContain('permissions')
+      expect(result.actions.some(a => a.action === 'diagnose')).toBe(true)
+      const task = getTask(db, 't1')!
+      expect(task.status).toBe('pending')
+    })
+
+    it('returns needs_human when branch is protected (main)', async () => {
+      createTask(db, { id: 't1', title: 'Protected branch task' })
+      updateTask(db, 't1', { status: 'failed', failure_reason: 'worktree_branch_exists', repo_path: repoPath, branch: 'main' })
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.verdict).toBe('needs_human')
+      expect(result.reason).toContain('protected')
+      // Task should NOT be reset
+      const task = getTask(db, 't1')!
+      expect(task.status).toBe('failed')
+    })
+
+    it('returns needs_human when branch is a run integration branch', async () => {
+      createTask(db, { id: 't1', title: 'Run branch task' })
+      updateTask(db, 't1', { status: 'failed', failure_reason: 'worktree_branch_exists', repo_path: repoPath, branch: 'mc/run-abc123' })
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.verdict).toBe('needs_human')
+      expect(result.reason).toContain('protected')
+    })
+
+    it('returns needs_human when preflightReconcile refuses (checked-out branch)', async () => {
+      git('git checkout -b feature/current-work', repoPath)
+      createTask(db, { id: 't1', title: 'Checked out branch' })
+      updateTask(db, 't1', { status: 'failed', failure_reason: 'worktree_branch_exists', repo_path: repoPath, branch: 'feature/current-work' })
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.verdict).toBe('needs_human')
+      expect(result.reason).toContain('Refusing to reconcile')
+    })
+  })
+
+  // --- Verdict: recovered ---
+
+  describe('recovered verdicts', () => {
+    it('returns recovered (noop) when task is already pending with no failure', async () => {
+      createTask(db, { id: 't1', title: 'Clean task' })
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.verdict).toBe('recovered')
+      expect(result.reason).toContain('already in a spawnable state')
+      expect(result.actions).toEqual([])
+    })
+
+    it('recovers worktree_branch_exists by running git reconcile', async () => {
+      git('git branch mc/t1', repoPath)
+      createTask(db, { id: 't1', title: 'Branch exists' })
+      updateTask(db, 't1', { status: 'failed', failure_reason: 'worktree_branch_exists', repo_path: repoPath, branch: 'mc/t1' })
+
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.verdict).toBe('recovered')
+      expect(result.actions.some(a => a.action.startsWith('git_reconcile:'))).toBe(true)
+      expect(result.actions.some(a => a.action === 'reset_task')).toBe(true)
+
+      const task = getTask(db, 't1')!
+      expect(task.status).toBe('pending')
+      expect(task.failure_reason).toBeNull()
+      expect(task.branch).toBeNull()
+    })
+
+    it('recovers worktree_branch_exists: deletes branch with no unique commits', async () => {
+      git('git branch mc/t-clean', repoPath)
+      createTask(db, { id: 't-clean', title: 'Clean branch' })
+      updateTask(db, 't-clean', { status: 'failed', failure_reason: 'worktree_branch_exists', repo_path: repoPath, branch: 'mc/t-clean' })
+
+      const result = await handleRecoverTask(db, 't-clean')
+      expect(result.verdict).toBe('recovered')
+      expect(result.actions.some(a => a.action === 'git_reconcile:delete-branch')).toBe(true)
+
+      const branches = git('git branch', repoPath)
+      expect(branches).not.toContain('mc/t-clean')
+    })
+
+    it('recovers worktree_branch_exists: preserves branch with unique commits (allocate-suffix)', async () => {
+      git('git checkout -b mc/t-unique', repoPath)
+      writeFileSync(join(repoPath, 'work.txt'), 'unique work')
+      git('git add . && git commit --no-gpg-sign -m "unique"', repoPath)
+      git('git checkout -', repoPath)
+
+      createTask(db, { id: 't-unique', title: 'Unique branch' })
+      updateTask(db, 't-unique', { status: 'failed', failure_reason: 'worktree_branch_exists', repo_path: repoPath, branch: 'mc/t-unique' })
+
+      const result = await handleRecoverTask(db, 't-unique')
+      expect(result.verdict).toBe('recovered')
+      expect(result.actions.some(a => a.action === 'git_reconcile:allocate-suffix')).toBe(true)
+
+      const branches = git('git branch', repoPath)
+      expect(branches).toContain('mc/t-unique')
+    })
+
+    it('recovers worktree_path_registered by cleaning up the registered worktree', async () => {
+      const wtPath = mkdtempSync(join(tmpdir(), 'mc-t-reg-'))
+      git(`git worktree add -b mc/t-reg "${wtPath}"`, repoPath)
+
+      createTask(db, { id: 't-reg', title: 'Registered worktree' })
+      updateTask(db, 't-reg', { status: 'failed', failure_reason: 'worktree_path_registered', repo_path: repoPath, branch: 'mc/t-reg', worktree_path: wtPath })
+
+      const result = await handleRecoverTask(db, 't-reg')
+      expect(result.verdict).toBe('recovered')
+      expect(result.actions.some(a => a.action === 'git_reconcile:remove-worktree')).toBe(true)
+
+      const task = getTask(db, 't-reg')!
+      expect(task.status).toBe('pending')
+      expect(task.worktree_path).toBeNull()
+
+      rmSync(wtPath, { recursive: true, force: true })
+    })
+
+    it('recovers worktree failure when branch does not exist (noop reconcile)', async () => {
+      createTask(db, { id: 't-gone', title: 'Branch already gone' })
+      updateTask(db, 't-gone', { status: 'failed', failure_reason: 'worktree_create_failed', repo_path: repoPath, branch: 'mc/t-gone' })
+
+      const result = await handleRecoverTask(db, 't-gone')
+      expect(result.verdict).toBe('recovered')
+      expect(result.actions.some(a => a.action === 'git_reconcile:noop')).toBe(true)
+    })
+
+    it('recovers worktree failure when no branch is stored (derives mc/{taskId})', async () => {
+      git('git branch mc/t-no-branch', repoPath)
+      createTask(db, { id: 't-no-branch', title: 'No branch stored' })
+      updateTask(db, 't-no-branch', { status: 'failed', failure_reason: 'worktree_branch_exists', repo_path: repoPath })
+
+      const result = await handleRecoverTask(db, 't-no-branch')
+      expect(result.verdict).toBe('recovered')
+      expect(result.actions.some(a => a.action === 'git_reconcile:delete-branch')).toBe(true)
+    })
+
+    it('skips git reconciliation when repo_path is not set', async () => {
+      createTask(db, { id: 't1', title: 'No repo path' })
+      updateTask(db, 't1', { status: 'failed', failure_reason: 'worktree_branch_exists' })
+
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.verdict).toBe('recovered')
+      expect(result.actions.some(a => a.action === 'git_reconcile:skip')).toBe(true)
+    })
+
+    it('recovers tmux_window_create_failed by reaping stale windows', async () => {
+      createTask(db, { id: 't1', title: 'Tmux window fail' })
+      updateTask(db, 't1', { status: 'failed', failure_reason: 'tmux_window_create_failed' })
+
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.verdict).toBe('recovered')
+      expect(mockEnsureTmuxSession).toHaveBeenCalled()
+      expect(mockReapStaleWindows).toHaveBeenCalledWith('multiclaude', 't1')
+      expect(result.actions.some(a => a.action === 'tmux_reap_stale_windows' && a.success)).toBe(true)
+
+      const task = getTask(db, 't1')!
+      expect(task.status).toBe('pending')
+    })
+
+    it('recovers tmux_window_create_failed even when tmux is unavailable', async () => {
+      mockEnsureTmuxSession.mockImplementation(() => { throw new Error('tmux not found') })
+      createTask(db, { id: 't1', title: 'Tmux unavailable' })
+      updateTask(db, 't1', { status: 'failed', failure_reason: 'tmux_window_create_failed' })
+
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.verdict).toBe('recovered')
+      expect(result.actions.some(a => a.action === 'tmux_reap_stale_windows' && !a.success)).toBe(true)
+      expect(result.actions.some(a => a.action === 'reset_task')).toBe(true)
+
+      const task = getTask(db, 't1')!
+      expect(task.status).toBe('pending')
+    })
+
+    it('recovers agent_launch_failed by clearing agent and resetting', async () => {
+      createTask(db, { id: 't1', title: 'Launch fail' })
+      updateTask(db, 't1', { status: 'failed', failure_reason: 'agent_launch_failed', agent_id: 'w-t1' })
+      registerAgent(db, { id: 'w-t1', task_id: 't1' })
+      updateAgent(db, 'w-t1', { status: 'running' })
+
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.verdict).toBe('recovered')
+      expect(result.actions.some(a => a.action === 'mark_agent_failed')).toBe(true)
+      expect(result.actions.some(a => a.action === 'reset_task')).toBe(true)
+
+      const agent = getAgent(db, 'w-t1')!
+      expect(agent.status).toBe('failed')
+      const task = getTask(db, 't1')!
+      expect(task.status).toBe('pending')
+      expect(task.agent_id).toBeNull()
+    })
+
+    it('recovers a task with no failure_reason (status failed only)', async () => {
+      createTask(db, { id: 't1', title: 'Generic fail' })
+      updateTask(db, 't1', { status: 'failed' })
+
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.verdict).toBe('recovered')
+      expect(result.actions.some(a => a.action === 'reset_task')).toBe(true)
+
+      const task = getTask(db, 't1')!
+      expect(task.status).toBe('pending')
+    })
+  })
+
+  // --- Idempotency ---
+
+  describe('idempotency', () => {
+    it('second call returns recovered with no actions after first recovery', async () => {
+      createTask(db, { id: 't1', title: 'Idempotent' })
+      updateTask(db, 't1', { status: 'failed', failure_reason: 'agent_launch_failed', agent_id: 'w-t1' })
+      registerAgent(db, { id: 'w-t1', task_id: 't1' })
+
+      const result1 = await handleRecoverTask(db, 't1')
+      expect(result1.verdict).toBe('recovered')
+      expect(result1.actions.length).toBeGreaterThan(0)
+
+      const result2 = await handleRecoverTask(db, 't1')
+      expect(result2.verdict).toBe('recovered')
+      expect(result2.reason).toContain('already in a spawnable state')
+      expect(result2.actions).toEqual([])
+    })
+
+    it('second call after git reconcile returns recovered with no actions', async () => {
+      git('git branch mc/t-idem', repoPath)
+      createTask(db, { id: 't-idem', title: 'Git idempotent' })
+      updateTask(db, 't-idem', { status: 'failed', failure_reason: 'worktree_branch_exists', repo_path: repoPath, branch: 'mc/t-idem' })
+
+      const result1 = await handleRecoverTask(db, 't-idem')
+      expect(result1.verdict).toBe('recovered')
+
+      const result2 = await handleRecoverTask(db, 't-idem')
+      expect(result2.verdict).toBe('recovered')
+      expect(result2.actions).toEqual([])
+    })
+  })
+
+  // --- Agent cleanup ---
+
+  describe('agent cleanup', () => {
+    it('kills tmux window when clearing stale agent', async () => {
+      createTask(db, { id: 't1', title: 'Agent with pane' })
+      updateTask(db, 't1', { status: 'failed', failure_reason: 'agent_launch_failed', agent_id: 'w-t1' })
+      registerAgent(db, { id: 'w-t1', task_id: 't1' })
+      updateAgent(db, 'w-t1', { status: 'running', tmux_pane: '@42' })
+
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.verdict).toBe('recovered')
+      expect(mockKillTmuxWindow).toHaveBeenCalledWith('@42')
+      expect(result.actions.some(a => a.action === 'kill_agent_tmux_window')).toBe(true)
+    })
+
+    it('does not mark agent failed if already failed', async () => {
+      createTask(db, { id: 't1', title: 'Already failed agent' })
+      updateTask(db, 't1', { status: 'failed', failure_reason: 'agent_launch_failed', agent_id: 'w-t1' })
+      registerAgent(db, { id: 'w-t1', task_id: 't1' })
+      updateAgent(db, 'w-t1', { status: 'failed' })
+
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.verdict).toBe('recovered')
+      expect(result.actions.some(a => a.action === 'mark_agent_failed')).toBe(false)
+    })
+
+    it('does not mark agent failed if already done', async () => {
+      createTask(db, { id: 't1', title: 'Done agent' })
+      updateTask(db, 't1', { status: 'failed', failure_reason: 'agent_launch_failed', agent_id: 'w-t1' })
+      registerAgent(db, { id: 'w-t1', task_id: 't1' })
+      updateAgent(db, 'w-t1', { status: 'done' })
+
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.actions.some(a => a.action === 'mark_agent_failed')).toBe(false)
+    })
+  })
+
+  // --- Task state after recovery ---
+
+  describe('task state after recovery', () => {
+    it('clears all transient fields but preserves repo_path and retry_count', async () => {
+      createTask(db, { id: 't1', title: 'Full state' })
+      updateTask(db, 't1', {
+        status: 'failed',
+        failure_reason: 'agent_launch_failed',
+        failure_detail: 'ENOENT: spawn claude ENOENT',
+        branch: 'mc/t1',
+        worktree_path: '/tmp/mc-t1-xxxx',
+        head_sha: 'abc123',
+        agent_id: 'w-t1',
+        started_at: '2026-01-01T00:00:00Z',
+        repo_path: repoPath,
+        retry_count: 2,
+      })
+      registerAgent(db, { id: 'w-t1', task_id: 't1' })
+
+      await handleRecoverTask(db, 't1')
+
+      const task = getTask(db, 't1')!
+      expect(task.status).toBe('pending')
+      expect(task.failure_reason).toBeNull()
+      expect(task.failure_detail).toBeNull()
+      expect(task.branch).toBeNull()
+      expect(task.worktree_path).toBeNull()
+      expect(task.head_sha).toBeNull()
+      expect(task.agent_id).toBeNull()
+      expect(task.started_at).toBeNull()
+      // Preserved fields
+      expect(task.repo_path).toBe(repoPath)
+      expect(task.retry_count).toBe(2)
+    })
+  })
+
+  // --- Report structure ---
+
+  describe('report structure', () => {
+    it('every action has action, success, and detail fields', async () => {
+      createTask(db, { id: 't1', title: 'Report test' })
+      updateTask(db, 't1', { status: 'failed', failure_reason: 'agent_launch_failed', agent_id: 'w-t1' })
+      registerAgent(db, { id: 'w-t1', task_id: 't1' })
+      updateAgent(db, 'w-t1', { status: 'running', tmux_pane: '@5' })
+
+      const result = await handleRecoverTask(db, 't1')
+      expect(result.task_id).toBe('t1')
+      for (const action of result.actions) {
+        expect(action).toHaveProperty('action')
+        expect(action).toHaveProperty('success')
+        expect(action).toHaveProperty('detail')
+        expect(typeof action.action).toBe('string')
+        expect(typeof action.success).toBe('boolean')
+        expect(typeof action.detail).toBe('string')
+      }
+    })
+
+    it('unrecoverable and needs_human verdicts include a reason', async () => {
+      createTask(db, { id: 't-done', title: 'Done' })
+      updateTask(db, 't-done', { status: 'done' })
+      const r1 = await handleRecoverTask(db, 't-done')
+      expect(r1.reason).toBeTruthy()
+
+      createTask(db, { id: 't-ip', title: 'In progress' })
+      updateTask(db, 't-ip', { status: 'in_progress' })
+      const r2 = await handleRecoverTask(db, 't-ip')
+      expect(r2.reason).toBeTruthy()
+    })
+  })
+})


### PR DESCRIPTION
Makes runs self-healing: the coordination server now detects and remediates the failure modes that previously required a human to run shell commands, and only escalates when remediation is genuinely impossible.

Closes #100
Closes #101

## Tasks included

| Task | What it does |
|---|---|
| **tmux-preflight-reap** | Reaps orphaned `mc-<taskId>` tmux windows before spawning. Duplicate windows with identical names were the root cause of silent `pid: null` spawn failures — `tmux -t session:name` resolves to the *first* match, so a stale window swallowed the launch. |
| **worktree-preflight-reconcile** | Reconciles stale git worktree registrations and leftover branches before creating a task worktree, instead of failing the spawn. |
| **spawn-error-capture** | Captures and classifies launch failures (`classifyLaunchError`) into `failure_reason` / `failure_detail` on both the agent and task rows, and logs them. Previously a failed spawn recorded `pid: null` and nothing else. |
| **recover-task-tool** | New `recover_task` MCP tool that diagnoses a failed task and returns a verdict: `recovered`, `unrecoverable`, or `needs_human`. |
| **auto-recovery-watcher** | Wires `recover_task` into the spawner watcher. A failed task is auto-recovered up to `MAX_RECOVERY_ATTEMPTS` (2); a `recovered` verdict re-spawns, anything else escalates with the reason recorded. |
| **escalation-policy-docs** | Documents the recovery/escalation policy in `CLAUDE.md` and `prompts/orchestrator.md`, including when the orchestrator should stop retrying. |
| **worktree-config-isolation-fix** (#100) | Worktree teardown now strips any stray `core.worktree` from the parent repo's shared `.git/config`, plus an `assertSharedConfigClean()` guard. |
| **merge-failure-attribution-fix** (#101) | Scopes the merge `try`/`catch` tightly so post-merge cleanup can no longer report a successful merge as `merge failed`; adds a distinct non-fatal `post_merge_cleanup_failed` reason; re-checks `git merge-base --is-ancestor` before failing, and handles a deleted local task branch without throwing. |

## Also in this PR

**Removed an accidentally committed `node_modules` symlink** (`3ff6fcf`). A worker's `git add -A` picked it up because `.gitignore` listed `node_modules/` with a trailing slash, which matches directories only — not a symlink of the same name. Checking out this branch replaced the real `node_modules` with a self-referential symlink and destroyed the installed dependencies. The trailing slash is now dropped so this cannot recur.

## Verification

Full suite on the merged result: **453 tests across 35 files, all passing.**

Both #100 and #101 were confirmed live during this run, not just in theory:

- `core.worktree` leaked into the parent repo twice mid-run, pointing at temp worktrees, leaving `git status` failing with `fatal: this operation must be run in a work tree`.
- The #100 and #101 tasks were *each* marked `merge failed` while their merge commits (`3b1180b`, `6b92f25`) were already on the run branch — the exact false-failure #101 fixes, reproduced by the fix's own merge.

## Known gap — follow-up worth filing

The #100 fix **sanitizes on teardown rather than preventing the write.** A `git grep` over `src/` finds no code that writes `core.worktree` — workers are isolated purely via `GIT_DIR` / `GIT_WORK_TREE` / `GIT_CEILING_DIRECTORIES` — so the write originates outside this repo's source (git itself, or the worker agent's own git usage). That means the parent repo is still momentarily broken *while a worker runs*, and is only repaired at teardown. Worth a follow-up issue to identify the writer and stop it at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
