### PR TITLE
fix: pass worker runtime into startSpawnerWatcher (unbreaks the build)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,6 +70,7 @@ function startSpawnerWatcher(
   db: Database.Database,
   mcpConfigPath: string,
   backend: RuntimeBackend,
+  runtime: WorkerRuntime,
   openTerminals: boolean = false,
   stuckWarningMinutes: number = 10,
   stuckTimeoutMinutes: number = 30,
@@ -361,7 +362,7 @@ function startSpawnerWatcher(
   const stuckSince = new Map<string, number>()
   setInterval(() => {
     checkStuckWorkers(db, stuckSince, stuckWarningMinutes, stuckTimeoutMinutes)
-    if (effectiveRuntime === 'tmux') {
+    if (runtime === 'tmux') {
       reapOrphanWindows(db)
     }
   }, 60_000)
@@ -426,7 +427,7 @@ async function main() {
   // Start watcher: polls DB for spawning agents and launches worker subprocesses
   const backend = createBackend(effectiveRuntime, { serverPort: port })
   startSpawnerWatcher(
-    db, mcpConfigPath, backend, openTerminals,
+    db, mcpConfigPath, backend, effectiveRuntime, openTerminals,
     multiclaudeConfig?.stuckWarningMinutes ?? 10,
     multiclaudeConfig?.stuckTimeoutMinutes ?? 30,
   )


### PR DESCRIPTION
`main` does not compile. `npm install` fails on its `prepare` → `build` hook:

```
src/cli.ts:364:9 - error TS2304: Cannot find name 'effectiveRuntime'.
```

`startSpawnerWatcher` referenced `effectiveRuntime`, which is a local `const` declared inside `main()` (line 417) and therefore not in scope in that function. Fixed by threading the runtime through as an explicit parameter; the single call site now passes `effectiveRuntime`.

## How this got in

Introduced in `494f92f` (tmux window reaping) and shipped via #102. It survived review because **vitest does not typecheck** — the full suite passed 453/453 on the merged result while `tsc` was failing the whole time. `npm run build` was never run before opening #102. Worth adding a typecheck step to CI, or an `npm run typecheck` invoked alongside the tests, so this class of break can't pass again.

## Verification

- `npx tsc --noEmit` — clean
- `npm run build` — succeeds
- `npx vitest run` — 453 tests across 35 files, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)