### PR TITLE
Expose merged_into_run per task in status output (#99)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,7 +282,18 @@ After spawning, enter the monitoring loop using `wait_for_event()`. This tool **
 
 ### 6. Create PR — After All Tasks Complete
 
-When all tasks in a run are done, workers will have assembled the run integration branch `mc/run-{runId}`. Create one PR for the entire run:
+When all tasks in a run are done, workers will have assembled the run integration branch `mc/run-{runId}`. Before opening the PR:
+
+**Assert every done task has `merged_into_run: true`.** From the `wait_for_event` or `get_system_status` response, inspect each done task's `merged_into_run` field. If any task has `merged_into_run` that is `false` or `null`, **do not open the PR**. Instead, list the affected tasks explicitly:
+
+```
+⚠️ Cannot create PR — the following tasks completed but their branches did not land on mc/run-{runId}:
+- task-id-1 (merged_into_run: null)
+- task-id-2 (merged_into_run: false)
+Escalating to user before proceeding.
+```
+
+Only proceed to PR creation once all done tasks have `merged_into_run: true`.
 
 1. Use the GitHub MCP tool (`mcp__github__create_pull_request`) to open a PR:
    - **head branch:** `mc/run-{runId}`

--- a/prompts/orchestrator.md
+++ b/prompts/orchestrator.md
@@ -146,7 +146,18 @@ After spawning, enter the monitoring loop using `wait_for_event()`. This tool **
 
 ### 6. Create PR — After All Tasks Complete
 
-When all tasks in a run are done, workers will have assembled the run integration branch `mc/run-{runId}`. Create one PR for the entire run:
+When all tasks in a run are done, workers will have assembled the run integration branch `mc/run-{runId}`. Before opening the PR:
+
+**Assert every done task has `merged_into_run: true`.** From the `wait_for_event` or `get_system_status` response, inspect each done task's `merged_into_run` field. If any task has `merged_into_run` that is `false` or `null`, **do not open the PR**. Instead, list the affected tasks explicitly:
+
+```
+⚠️ Cannot create PR — the following tasks completed but their branches did not land on mc/run-{runId}:
+- task-id-1 (merged_into_run: null)
+- task-id-2 (merged_into_run: false)
+Escalating to user before proceeding.
+```
+
+Only proceed to PR creation once all done tasks have `merged_into_run: true`.
 
 1. Use the GitHub MCP tool (`mcp__github__create_pull_request`) to open a PR:
    - **head branch:** `mc/run-{runId}`

--- a/src/server/state/db.ts
+++ b/src/server/state/db.ts
@@ -98,6 +98,7 @@ export function createDb(path: string = './multiclaude.db'): Database.Database {
   try { db.exec("ALTER TABLE agents ADD COLUMN failure_reason TEXT") } catch { /* already exists */ }
   try { db.exec("ALTER TABLE agents ADD COLUMN failure_detail TEXT") } catch { /* already exists */ }
   try { db.exec("ALTER TABLE tasks ADD COLUMN recovery_attempts INTEGER NOT NULL DEFAULT 0") } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE tasks ADD COLUMN merged_into_run INTEGER") } catch { /* already exists */ }
   return db
 }
 

--- a/src/server/state/tasks.ts
+++ b/src/server/state/tasks.ts
@@ -27,6 +27,7 @@ export interface Task {
   failure_reason: string | null
   failure_detail: string | null
   recovery_attempts: number
+  merged_into_run: boolean | null
   created_at: string
   updated_at: string
 }
@@ -59,6 +60,14 @@ export interface UpdateTaskInput {
   failure_reason?: string
   failure_detail?: string
   recovery_attempts?: number
+  merged_into_run?: boolean
+}
+
+function mapTask(row: Record<string, unknown>): Task {
+  return {
+    ...(row as any),
+    merged_into_run: row.merged_into_run == null ? null : Boolean(row.merged_into_run),
+  }
 }
 
 export function createTask(db: Database.Database, input: CreateTaskInput): void {
@@ -78,7 +87,8 @@ export function createTask(db: Database.Database, input: CreateTaskInput): void 
 }
 
 export function getTask(db: Database.Database, id: string): Task | null {
-  return (db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as Task | undefined) ?? null
+  const row = db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as Record<string, unknown> | undefined
+  return row ? mapTask(row) : null
 }
 
 export function updateTask(db: Database.Database, id: string, input: UpdateTaskInput): void {
@@ -101,13 +111,14 @@ export function updateTask(db: Database.Database, id: string, input: UpdateTaskI
   if (input.failure_reason !== undefined) { sets.push('failure_reason = @failure_reason'); params.failure_reason = input.failure_reason }
   if (input.failure_detail !== undefined) { sets.push('failure_detail = @failure_detail'); params.failure_detail = input.failure_detail }
   if (input.recovery_attempts !== undefined) { sets.push('recovery_attempts = @recovery_attempts'); params.recovery_attempts = input.recovery_attempts }
+  if (input.merged_into_run !== undefined) { sets.push('merged_into_run = @merged_into_run'); params.merged_into_run = input.merged_into_run ? 1 : 0 }
 
   db.prepare(`UPDATE tasks SET ${sets.join(', ')} WHERE id = @id`).run(params as any)
 }
 
 export function listTasks(db: Database.Database, status?: TaskStatus): Task[] {
   if (status) {
-    return db.prepare('SELECT * FROM tasks WHERE status = ? ORDER BY created_at').all(status) as Task[]
+    return (db.prepare('SELECT * FROM tasks WHERE status = ? ORDER BY created_at').all(status) as Record<string, unknown>[]).map(mapTask)
   }
-  return db.prepare('SELECT * FROM tasks ORDER BY created_at').all() as Task[]
+  return (db.prepare('SELECT * FROM tasks ORDER BY created_at').all() as Record<string, unknown>[]).map(mapTask)
 }

--- a/src/server/tools/worker.ts
+++ b/src/server/tools/worker.ts
@@ -47,6 +47,9 @@ export async function handleReportDone(
     ? calculateCost(opts.input_tokens, opts.output_tokens, model)
     : undefined
 
+  // Tracks whether task branch landed on the run integration branch. null = no merge attempted.
+  let mergedIntoRun: boolean | null = null
+
   // Merge worktree branch into mc/integration and remove worktree if one was created
   if (task?.worktree_path && task.branch) {
     const projectCwd = task.repo_path ?? (task.run_id
@@ -86,6 +89,7 @@ export async function handleReportDone(
       try {
         await ensureIntegrationBranch(projectCwd, runId)
         await mergeWorktreeBranch(projectCwd, task.branch, runId, task.worktree_path)
+        mergedIntoRun = true
         db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
           taskId, 'info', `Merged and pushed ${task.branch} to origin/${integBranch}`
         )
@@ -99,6 +103,8 @@ export async function handleReportDone(
         try {
           landed = await isMergedInto(projectCwd, task.branch, integBranch)
         } catch { /* conservative: assume not landed */ }
+
+        mergedIntoRun = landed
 
         if (landed) {
           // Merge landed; error came from post-merge code inside mergeWorktreeBranch.
@@ -143,6 +149,7 @@ export async function handleReportDone(
     output_tokens: opts.output_tokens,
     total_tokens: opts.total_tokens,
     cost_usd,
+    ...(mergedIntoRun !== null && { merged_into_run: mergedIntoRun }),
   })
   db.prepare(
     'INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)'

--- a/tests/tools/merged-into-run.test.ts
+++ b/tests/tools/merged-into-run.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for merged_into_run field (#99):
+ * - Persisted on task when branch lands on the run integration branch
+ * - Null when no merge was attempted (task had no worktree)
+ * - Surfaced in get_system_status and wait_for_event
+ * - True even when task reaches done via the post_merge_cleanup_failed path
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const {
+  mockEnsureIntegrationBranch,
+  mockMergeWorktreeBranch,
+  mockIsMergedInto,
+  mockRemoveWorktree,
+  mockKillTmuxWindow,
+} = vi.hoisted(() => ({
+  mockEnsureIntegrationBranch: vi.fn<() => Promise<void>>(),
+  mockMergeWorktreeBranch: vi.fn<() => Promise<void>>(),
+  mockIsMergedInto: vi.fn<() => Promise<boolean>>(),
+  mockRemoveWorktree: vi.fn<() => Promise<void>>(),
+  mockKillTmuxWindow: vi.fn(),
+}))
+
+vi.mock('../../src/git/merge.js', () => ({
+  ensureIntegrationBranch: mockEnsureIntegrationBranch,
+  mergeWorktreeBranch: mockMergeWorktreeBranch,
+  isMergedInto: mockIsMergedInto,
+  MergeConflictError: class MergeConflictError extends Error {
+    taskBranch: string; integBranch: string; conflictedFiles: string[]
+    constructor(taskBranch: string, integBranch: string, conflictedFiles: string[]) {
+      super(`Merge conflict: ${taskBranch} → ${integBranch}`)
+      this.name = 'MergeConflictError'
+      this.taskBranch = taskBranch
+      this.integBranch = integBranch
+      this.conflictedFiles = conflictedFiles
+    }
+  },
+}))
+
+vi.mock('../../src/git/worktree.js', () => ({
+  removeWorktree: mockRemoveWorktree,
+}))
+
+vi.mock('../../src/spawner/tmux.js', () => ({
+  killTmuxWindow: mockKillTmuxWindow,
+  captureTmuxPane: vi.fn(() => ''),
+  spawnTmuxWorker: vi.fn(),
+  ensureTmuxSession: vi.fn(() => 'multiclaude'),
+  createTmuxWindow: vi.fn(() => '@1'),
+}))
+
+import { createDb, closeDb } from '../../src/server/state/db.js'
+import { createTask, updateTask, getTask } from '../../src/server/state/tasks.js'
+import { handleReportDone } from '../../src/server/tools/worker.js'
+import { handleGetSystemStatus, handleWaitForEvent } from '../../src/server/tools/orchestrator.js'
+import type Database from 'better-sqlite3'
+
+function setupTaskWithWorktree(db: Database.Database, id = 't1') {
+  createTask(db, { id, title: 'Test task' })
+  updateTask(db, id, {
+    status: 'in_progress',
+    worktree_path: '/tmp/fake-worktree',
+    branch: 'feature/test',
+    head_sha: null, // skip empty-branch check
+    repo_path: '/fake/repo',
+  })
+}
+
+function setupTaskNoWorktree(db: Database.Database, id = 't1') {
+  createTask(db, { id, title: 'Test task' })
+  updateTask(db, id, { status: 'in_progress' })
+}
+
+describe('merged_into_run persistence', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = createDb(':memory:')
+    mockEnsureIntegrationBranch.mockReset().mockResolvedValue(undefined)
+    mockMergeWorktreeBranch.mockReset().mockResolvedValue(undefined)
+    mockIsMergedInto.mockReset().mockResolvedValue(false)
+    mockRemoveWorktree.mockReset().mockResolvedValue(undefined)
+    mockKillTmuxWindow.mockReset()
+  })
+
+  afterEach(() => { closeDb(db) })
+
+  it('merged_into_run is true when merge succeeds', async () => {
+    setupTaskWithWorktree(db)
+    mockMergeWorktreeBranch.mockResolvedValue(undefined)
+
+    await handleReportDone(db, 't1', 'feature done')
+
+    const task = getTask(db, 't1')
+    expect(task?.status).toBe('done')
+    expect(task?.merged_into_run).toBe(true)
+  })
+
+  it('merged_into_run is null when task had no worktree (no merge attempted)', async () => {
+    setupTaskNoWorktree(db)
+
+    await handleReportDone(db, 't1', 'done')
+
+    const task = getTask(db, 't1')
+    expect(task?.status).toBe('done')
+    expect(task?.merged_into_run).toBeNull()
+  })
+
+  it('merged_into_run is null (absent) when task fails because branch did not land', async () => {
+    setupTaskWithWorktree(db)
+    mockMergeWorktreeBranch.mockRejectedValue(new Error('merge conflict'))
+    mockIsMergedInto.mockResolvedValue(false)
+
+    await handleReportDone(db, 't1', 'done')
+
+    const task = getTask(db, 't1')
+    expect(task?.status).toBe('failed')
+    expect(task?.merged_into_run).toBeNull()
+  })
+
+  it('merged_into_run is true via post_merge_cleanup_failed path (#101)', async () => {
+    // mergeWorktreeBranch throws a post-merge error but branch actually landed
+    setupTaskWithWorktree(db)
+    mockMergeWorktreeBranch.mockRejectedValue(new Error('push to origin failed'))
+    mockIsMergedInto.mockResolvedValue(true)
+
+    await handleReportDone(db, 't1', 'done')
+
+    const task = getTask(db, 't1')
+    expect(task?.status).toBe('done')
+    expect(task?.merged_into_run).toBe(true)
+  })
+
+  it('merged_into_run is true even when removeWorktree throws after successful merge', async () => {
+    setupTaskWithWorktree(db)
+    mockMergeWorktreeBranch.mockResolvedValue(undefined)
+    mockRemoveWorktree.mockRejectedValue(new Error('worktree already removed'))
+
+    await handleReportDone(db, 't1', 'done')
+
+    const task = getTask(db, 't1')
+    expect(task?.status).toBe('done')
+    expect(task?.merged_into_run).toBe(true)
+  })
+})
+
+describe('merged_into_run in system status output', () => {
+  let db: Database.Database
+
+  beforeEach(() => { db = createDb(':memory:') })
+  afterEach(() => { closeDb(db) })
+
+  it('get_system_status includes merged_into_run on each task', () => {
+    db.prepare("INSERT INTO tasks (id, title, status, merged_into_run) VALUES ('t1', 'Task', 'done', 1)").run()
+    const status = handleGetSystemStatus(db, true)
+    const task = status.tasks.find(t => t.id === 't1')
+    expect(task).toBeDefined()
+    expect('merged_into_run' in task!).toBe(true)
+    expect(task!.merged_into_run).toBe(true)
+  })
+
+  it('get_system_status surfaces merged_into_run as a JS boolean (not raw 0/1)', () => {
+    db.prepare("INSERT INTO tasks (id, title, status, merged_into_run) VALUES ('t1', 'Task', 'done', 1)").run()
+    db.prepare("INSERT INTO tasks (id, title, status, merged_into_run) VALUES ('t2', 'Task', 'done', 0)").run()
+    const status = handleGetSystemStatus(db, true)
+    const t1 = status.tasks.find(t => t.id === 't1')!
+    const t2 = status.tasks.find(t => t.id === 't2')!
+    expect(t1.merged_into_run).toBe(true)
+    expect(typeof t1.merged_into_run).toBe('boolean')
+    expect(t2.merged_into_run).toBe(false)
+    expect(typeof t2.merged_into_run).toBe('boolean')
+  })
+
+  it('get_system_status returns null for tasks with no merged_into_run value', () => {
+    db.prepare("INSERT INTO tasks (id, title, status) VALUES ('t1', 'Task', 'done')").run()
+    const status = handleGetSystemStatus(db, true)
+    const task = status.tasks.find(t => t.id === 't1')!
+    expect(task.merged_into_run).toBeNull()
+  })
+
+  it('wait_for_event includes merged_into_run in task output', async () => {
+    db.prepare("INSERT INTO tasks (id, title, status, merged_into_run) VALUES ('t1', 'Task', 'in_progress', 1)").run()
+    setTimeout(() => {
+      db.prepare("UPDATE tasks SET status = 'done' WHERE id = 't1'").run()
+    }, 200)
+    const result = await handleWaitForEvent(db, 5, true)
+    const task = result.tasks.find(t => t.id === 't1')
+    expect(task).toBeDefined()
+    expect(task!.merged_into_run).toBe(true)
+  })
+
+  it('wait_for_event surfaces merged_into_run as a JS boolean', async () => {
+    db.prepare("INSERT INTO tasks (id, title, status, merged_into_run) VALUES ('t1', 'Task', 'in_progress', 1)").run()
+    setTimeout(() => {
+      db.prepare("UPDATE tasks SET status = 'done' WHERE id = 't1'").run()
+    }, 200)
+    const result = await handleWaitForEvent(db, 5, true)
+    const task = result.tasks.find(t => t.id === 't1')!
+    expect(typeof task.merged_into_run).toBe('boolean')
+    expect(task.merged_into_run).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #99

The last outstanding acceptance criterion from #95: let the orchestrator confirm a run branch actually contains every task's work **without diffing files**. Diffing is what made the original #95 failure invisible until a human happened to notice.

## What changed

| File | Change |
|---|---|
| `src/server/state/db.ts` | `merged_into_run INTEGER` column via the existing `ALTER TABLE … try/catch` migration pattern |
| `src/server/state/tasks.ts` | Field on the `Task` type; row mapper converts `0/1` → real boolean (`null` when never set); update path converts back |
| `src/server/tools/worker.ts` | Persists the value `handleReportDone` was already computing and discarding |

`src/server/tools/orchestrator.ts` needed no change — `get_system_status` and `wait_for_event` build their task list through `enrichWithLastLog(db, listTasks(...))`, so the field flows out via the `tasks.ts` row mapper automatically. Verified rather than assumed.

Scope was smaller than the issue text describes, because work merged after #99 was filed already did part of it: `isMergedInto()` existed in `src/git/merge.ts`, and `failure_reason` / `failure_detail` / `head_sha` were already persisted and surfaced.

## The three states

- **Merge succeeds** → `merged_into_run: true`
- **Merge lands but post-merge cleanup throws** (the #101 path) → still `true`, cleanup logged separately as `post_merge_cleanup_failed`
- **Genuine non-ancestor** → task marked `failed`, returns early

The value is written once at `report_done`, not recomputed per call — `wait_for_event` is polled continuously and must not shell out to git per task per poll.

## Docs

Step 6 in both `prompts/orchestrator.md` and `CLAUDE.md` now requires asserting every `done` task has `merged_into_run: true` before opening a run PR, and listing any that don't instead of opening it silently.

## Verification

- `npx tsc --noEmit` — clean
- `npm run build` — succeeds
- `npx vitest run` — **463 tests across 36 files, all passing** (up from 453/35 on main: +10 tests, +1 file)

The typecheck and build steps were run explicitly this time. A green vitest run does not imply the code compiles — that gap is what let the build break in #102 through, and it was written into this task's brief as a required gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
