### PR TITLE
Enforce worker worktree boundary for file operations (#109)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,13 @@ src/server/state/        SQLite state via better-sqlite3 (WAL mode).
 
 src/spawner/index.ts     spawnWorker(): launches `claude` subprocess with --mcp-config,
                          --dangerously-skip-permissions, and a prompt injected via CLI arg.
-                         Writes .claude/settings.local.json into the worktree before spawning.
+                         Writes .claude/settings.local.json into the worktree before spawning
+                         (worktree-scoped Write/Edit permissions + PreToolUse boundary hook).
+src/spawner/worktree-guard.ts      isPathInWorktree(): symlink-aware, case-insensitive path
+                                   containment check used by the PreToolUse hook.
+src/spawner/worktree-guard-hook.ts PreToolUse hook entrypoint (node script). Denies Write/Edit/
+                                   Read/NotebookEdit calls that target paths outside the worktree;
+                                   logs violations to .claude/boundary-violations.log.
 src/spawner/cursor.ts    Cursor worker variant — uses node-pty for PTY requirement.
 src/spawner/tmux.ts      Tmux worker backend: ensureTmuxSession, createTmuxWindow, spawnTmuxWorker,
                          captureTmuxPane, sendToPane (with composer-submit robustness), and
@@ -95,6 +101,22 @@ tests/                   Vitest test suite (644 tests across 44 files).
 ### Git isolation model
 
 Each task gets its own git worktree in a temp directory (`/tmp/mc-<taskId>-XXXX/`) on a branch like `feature/task-slug` or `fix/task-slug`. When a worker calls `report_done`, the server merges the task branch into a per-run integration branch (`mc/run-<runId>`). The orchestrator creates a PR from that integration branch to `main` after all tasks complete.
+
+### File-operation boundary
+
+Each worker's `Write` and `Edit` permissions are scoped to its own worktree path in `.claude/settings.local.json` (built by `buildWorkerSettings` in `src/spawner/index.ts`). A `PreToolUse` hook — `src/spawner/worktree-guard-hook.ts`, backed by `src/spawner/worktree-guard.ts` — intercepts every `Write`, `Edit`, `Read`, and `NotebookEdit` tool call and denies any path outside the assigned worktree (exit code 2). The hook resolves symlinks on both sides (handling `/tmp` → `/private/tmp` on macOS) and performs case-insensitive comparison, so path traversal and symlink escape attempts are caught.
+
+The parent repository path (`repo_path`) is withheld from the `WorkerTaskView` returned by `get_my_task`, so workers have no in-band way to learn the path. If `repoPath` is known at spawn time, an explicit `deny` rule for that path is added alongside the `allow` rules.
+
+The hook is registered in all three worker launch paths:
+
+| Launch path | Where settings are written |
+|-------------|---------------------------|
+| `spawnWorker` (`src/spawner/index.ts`) | `.claude/settings.local.json` in the worktree before `spawn()` |
+| `spawnTmuxWorker` (`src/spawner/tmux.ts`) | same, before the tmux window is created |
+| `spawnCursorWorker` (`src/spawner/cursor.ts`) | same; Cursor does not currently read this file, but the file is present for defence-in-depth |
+
+**Where violations surface:** Denied attempts are appended as JSON lines to `.claude/boundary-violations.log` inside the worker's worktree (`{ timestamp, tool, path, taskId }`). The worker receives a structured error message explaining which path was denied and why.
 
 ### Self-service git pipeline
 

--- a/prompts/worker.md
+++ b/prompts/worker.md
@@ -40,7 +40,7 @@ You have access to the `multiclaude-coord` MCP server with worker-scoped tools.
 ## Key Principles
 
 - **CRITICAL: Git isolation is enforced.** Your process environment locks all git operations to your assigned worktree via `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_CEILING_DIRECTORIES`. Do NOT unset or override these environment variables. Do NOT checkout other branches. All commits must land on your task branch only.
-- **Stay in your worktree directory.** Do not `cd` to the parent repository or any other git repository. Your working directory is your worktree path.
+- **CRITICAL: File-operation boundary is enforced.** A `PreToolUse` hook (`src/spawner/worktree-guard-hook.ts`) intercepts every `Write`, `Edit`, `Read`, and `NotebookEdit` tool call and denies any path outside your assigned worktree. Denied attempts are logged to `.claude/boundary-violations.log` inside your worktree. The task payload returned by `get_my_task` does not include the parent repository path — if you believe you need a file from outside your worktree, call `report_blocked` and explain what you need; do not attempt to access it directly.
 - Write tests before implementation (TDD).
 - Commit frequently with descriptive messages.
 - Do not ask the user questions — you work autonomously. If truly ambiguous, document your assumption in a comment and proceed.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -218,6 +218,7 @@ function startSpawnerWatcher(
         worktreePath: agent.cwd,
         mcpConfigPath,
         openTerminals,
+        repoPath: task.repo_path ?? undefined,
       }
 
       let handle
@@ -350,6 +351,25 @@ function startSpawnerWatcher(
             db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
               agent.task_id, 'warn', `[claude-cli] ${warning}`
             )
+          }
+          // Surface boundary violations so the operator sees them via normal status tools.
+          if (agent.cwd) {
+            const violationsPath = join(agent.cwd, '.claude', 'boundary-violations.log')
+            if (existsSync(violationsPath)) {
+              try {
+                const lines = readFileSync(violationsPath, 'utf8').trim().split('\n')
+                for (const line of lines) {
+                  if (!line.trim()) continue
+                  try {
+                    const entry = JSON.parse(line) as { tool?: string; path?: string }
+                    db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
+                      agent.task_id, 'error',
+                      `[boundary-violation] ${entry.tool ?? 'unknown'} attempted to access "${entry.path ?? '?'}" outside worktree`
+                    )
+                  } catch { /* skip malformed violation entries */ }
+                }
+              } catch { /* log read failure is non-fatal */ }
+            }
           }
         }
       })

--- a/src/server/tools/worker.ts
+++ b/src/server/tools/worker.ts
@@ -8,7 +8,16 @@ import { removeWorktree } from '../../git/worktree.js'
 import { calculateCost } from '../cost.js'
 import { killTmuxWindow } from '../../spawner/tmux.js'
 
-export function handleGetMyTask(db: Database.Database, agentId: string): Task {
+export type WorkerTaskView = Pick<
+  Task,
+  | 'id' | 'title' | 'description' | 'status' | 'model' | 'effort'
+  | 'retry_count' | 'max_retries' | 'worktree_path' | 'branch' | 'head_sha'
+  | 'agent_id' | 'started_at' | 'run_id' | 'ticket'
+  | 'failure_reason' | 'failure_detail' | 'conflict_worker_for'
+  | 'created_at' | 'updated_at'
+>
+
+export function handleGetMyTask(db: Database.Database, agentId: string): WorkerTaskView {
   const task = db.prepare(
     "SELECT * FROM tasks WHERE agent_id = ? AND status = 'in_progress'"
   ).get(agentId) as Task | undefined
@@ -17,7 +26,28 @@ export function handleGetMyTask(db: Database.Database, agentId: string): Task {
   // Mark agent as running now that it has acknowledged its task
   updateAgent(db, agentId, { status: 'running' })
 
-  return task
+  return {
+    id: task.id,
+    title: task.title,
+    description: task.description,
+    status: task.status,
+    model: task.model,
+    effort: task.effort,
+    retry_count: task.retry_count,
+    max_retries: task.max_retries,
+    worktree_path: task.worktree_path,
+    branch: task.branch,
+    head_sha: task.head_sha,
+    agent_id: task.agent_id,
+    started_at: task.started_at,
+    run_id: task.run_id,
+    ticket: task.ticket,
+    failure_reason: task.failure_reason,
+    failure_detail: task.failure_detail,
+    conflict_worker_for: task.conflict_worker_for,
+    created_at: task.created_at,
+    updated_at: task.updated_at,
+  }
 }
 
 export function handleReportProgress(

--- a/src/spawner/cursor.ts
+++ b/src/spawner/cursor.ts
@@ -4,7 +4,7 @@ import { writeFileSync, mkdirSync, appendFileSync } from 'fs'
 import { join } from 'path'
 
 import type { SpawnConfig } from './index.js'
-import { workerLogPath } from './index.js'
+import { workerLogPath, buildWorkerSettings } from './index.js'
 
 // Cursor MCP config format (written to <worktree>/.cursor/mcp.json)
 export interface CursorMcpConfig {
@@ -122,6 +122,16 @@ export function spawnCursorWorker(cfg: SpawnConfig & { serverPort: number }): IP
   // Write MCP config and rules into the worktree before starting
   writeCursorWorkerMcpConfig({ serverPort: cfg.serverPort, worktreePath: cfg.worktreePath })
   writeCursorWorkerRules(cfg)
+
+  // Write .claude/settings.local.json with scoped permissions and the boundary-guard
+  // hook. Cursor does not currently read this file, but defence-in-depth means it
+  // is present if Claude Code is ever opened in the same worktree.
+  const claudeDir = join(cfg.worktreePath, '.claude')
+  mkdirSync(claudeDir, { recursive: true })
+  writeFileSync(
+    join(claudeDir, 'settings.local.json'),
+    JSON.stringify(buildWorkerSettings({ worktreePath: cfg.worktreePath, repoPath: cfg.repoPath }), null, 2)
+  )
 
   const logPath = workerLogPath(cfg.agentId)
   const args = buildCursorWorkerArgs()

--- a/src/spawner/index.ts
+++ b/src/spawner/index.ts
@@ -8,6 +8,19 @@ import { readWorktreeGitDir } from '../git/worktree.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
+/**
+ * Returns the shell command to invoke the boundary-guard PreToolUse hook.
+ * Prefers the compiled .js (production: dist/spawner/) over tsx source (development).
+ */
+export function resolveHookCommand(): string {
+  const jsPath = join(__dirname, 'worktree-guard-hook.js')
+  if (existsSync(jsPath)) {
+    return `node ${JSON.stringify(jsPath)}`
+  }
+  const tsPath = join(__dirname, 'worktree-guard-hook.ts')
+  return `npx tsx ${JSON.stringify(tsPath)}`
+}
+
 const MODEL_IDS: Record<string, string> = {
   haiku: 'claude-haiku-4-5-20251001',
   sonnet: 'claude-sonnet-4-6',
@@ -24,6 +37,8 @@ export interface SpawnConfig {
   worktreePath: string
   mcpConfigPath: string
   openTerminals?: boolean
+  /** Absolute path to the parent project repo — used to generate deny rules. */
+  repoPath?: string
 }
 
 export interface WorkerMcpConfig {
@@ -48,7 +63,14 @@ export interface WorktreeIsolation {
   gitDir: string
 }
 
-export function buildWorkerEnv(agentId: string, isolation?: WorktreeIsolation): NodeJS.ProcessEnv {
+export interface WorkerEnvOpts {
+  /** Task ID — forwarded as MULTICLAUDE_TASK_ID for the boundary-guard hook. */
+  taskId?: string
+  /** Worktree root — forwarded as MULTICLAUDE_WORKTREE when isolation is unavailable. */
+  worktreePath?: string
+}
+
+export function buildWorkerEnv(agentId: string, isolation?: WorktreeIsolation, opts?: WorkerEnvOpts): NodeJS.ProcessEnv {
   const env: Record<string, string | undefined> = { ...process.env, MULTICLAUDE_AGENT_ID: agentId }
   delete env['CLAUDECODE']
   if (isolation) {
@@ -56,6 +78,10 @@ export function buildWorkerEnv(agentId: string, isolation?: WorktreeIsolation): 
     env.GIT_WORK_TREE = isolation.worktreePath
     env.GIT_CEILING_DIRECTORIES = dirname(isolation.worktreePath)
   }
+  // MULTICLAUDE_WORKTREE is inherited by the boundary-guard PreToolUse hook subprocess.
+  const worktreePath = isolation?.worktreePath ?? opts?.worktreePath
+  if (worktreePath) env.MULTICLAUDE_WORKTREE = worktreePath
+  if (opts?.taskId) env.MULTICLAUDE_TASK_ID = opts.taskId
   return env
 }
 
@@ -120,6 +146,63 @@ export function buildWorkerArgs(cfg: SpawnConfig): string[] {
   ]
 }
 
+/**
+ * Builds the settings.local.json content for a worker's .claude/ directory.
+ *
+ * Write and Edit permissions are scoped to the worktree path so Claude Code's
+ * built-in permission layer blocks obvious out-of-tree writes immediately.
+ * The boundary-guard PreToolUse hook catches traversal and symlink escape cases
+ * that glob rules cannot express.
+ *
+ * Bash(*) cannot be path-constrained by glob patterns in Claude Code's
+ * permission system — there is no Bash(path) equivalent. Isolation relies on
+ * the worktree-scoped cwd, the GIT_DIR/GIT_WORK_TREE env vars in buildWorkerEnv,
+ * and the hook (which does not intercept Bash because it cannot determine the
+ * effective filesystem paths from the command string alone).
+ */
+export function buildWorkerSettings(cfg: {
+  worktreePath: string
+  repoPath?: string
+}): object {
+  const hookCommand = resolveHookCommand()
+
+  const allow = [
+    // Bash cannot be scoped to a path via Claude Code's glob permission format.
+    // cwd isolation (worktree as cwd) and GIT_DIR env vars limit its blast radius.
+    'Bash(*)',
+    `Write(${cfg.worktreePath}/**)`,
+    `Edit(${cfg.worktreePath}/**)`,
+    'Read(*)',
+    'mcp__multiclaude-worker__get_my_task',
+    'mcp__multiclaude-worker__report_progress',
+    'mcp__multiclaude-worker__report_done',
+    'mcp__multiclaude-worker__report_blocked',
+  ]
+
+  // Explicitly deny writes to the parent project repo so even if a glob rule
+  // were widened in the future, the deny takes precedence.
+  const deny: string[] = []
+  if (cfg.repoPath) {
+    deny.push(`Write(${cfg.repoPath}/**)`, `Edit(${cfg.repoPath}/**)`)
+  }
+
+  return {
+    permissions: {
+      allow,
+      ...(deny.length > 0 && { deny }),
+    },
+    hooks: {
+      PreToolUse: [
+        {
+          // Match every tool — the hook only acts on Write/Edit/Read/NotebookEdit paths.
+          matcher: '.*',
+          hooks: [{ type: 'command', command: hookCommand }],
+        },
+      ],
+    },
+  }
+}
+
 export function workerLogPath(agentId: string): string {
   return join(tmpdir(), `mc-worker-${agentId}.log`)
 }
@@ -133,14 +216,7 @@ export function spawnWorker(cfg: SpawnConfig): ChildProcess {
     mkdirSync(claudeDir, { recursive: true })
     writeFileSync(
       join(claudeDir, 'settings.local.json'),
-      JSON.stringify({ permissions: { allow:
-        ['Bash(*)', 'Write(*)', 'Edit(*)', 'Read(*)',
-          'mcp__multiclaude-worker__get_my_task',
-          'mcp__multiclaude-worker__report_progress',
-          'mcp__multiclaude-worker__report_done',
-          'mcp__multiclaude-worker__report_blocked'
-        ]
-       } }, null, 2)
+      JSON.stringify(buildWorkerSettings({ worktreePath: cfg.worktreePath, repoPath: cfg.repoPath }), null, 2)
     )
   } catch (err: unknown) {
     const detail = err instanceof Error ? err.message : String(err)
@@ -151,7 +227,7 @@ export function spawnWorker(cfg: SpawnConfig): ChildProcess {
   return spawn('claude', buildWorkerArgs(cfg), {
     cwd: cfg.worktreePath,
     stdio: ['ignore', logFd, logFd],
-    env: buildWorkerEnv(cfg.agentId, isolation),
+    env: buildWorkerEnv(cfg.agentId, isolation, { taskId: cfg.taskId, worktreePath: cfg.worktreePath }),
   })
 }
 

--- a/src/spawner/tmux.ts
+++ b/src/spawner/tmux.ts
@@ -4,7 +4,7 @@ import { join } from 'path'
 
 import type Database from 'better-sqlite3'
 import type { SpawnConfig } from './index.js'
-import { buildWorkerArgs, buildWorkerEnv } from './index.js'
+import { buildWorkerArgs, buildWorkerEnv, buildWorkerSettings } from './index.js'
 import { readWorktreeGitDir } from '../git/worktree.js'
 import type { WorktreeIsolation } from './index.js'
 import type { WorkerHandle } from './backend.js'
@@ -369,7 +369,7 @@ export function writeLaunchScript(cfg: SpawnConfig): string {
     const gitDir = readWorktreeGitDir(cfg.worktreePath)
     isolation = { worktreePath: cfg.worktreePath, gitDir }
   } catch { /* not a worktree — skip isolation */ }
-  const env = buildWorkerEnv(cfg.agentId, isolation)
+  const env = buildWorkerEnv(cfg.agentId, isolation, { taskId: cfg.taskId, worktreePath: cfg.worktreePath })
 
   const lines: string[] = ['#!/usr/bin/env bash', 'set -e', '']
   for (const [key, val] of Object.entries(env)) {
@@ -405,13 +405,7 @@ export function spawnTmuxWorker(cfg: SpawnConfig): WorkerHandle {
     mkdirSync(claudeDir, { recursive: true })
     writeFileSync(
       join(claudeDir, 'settings.local.json'),
-      JSON.stringify({ permissions: { allow: [
-        'Bash(*)', 'Write(*)', 'Edit(*)', 'Read(*)',
-        'mcp__multiclaude-worker__get_my_task',
-        'mcp__multiclaude-worker__report_progress',
-        'mcp__multiclaude-worker__report_done',
-        'mcp__multiclaude-worker__report_blocked',
-      ] } }, null, 2)
+      JSON.stringify(buildWorkerSettings({ worktreePath: cfg.worktreePath, repoPath: cfg.repoPath }), null, 2)
     )
   } catch (err: unknown) {
     const detail = err instanceof Error ? err.message : String(err)

--- a/src/spawner/worktree-guard-hook.ts
+++ b/src/spawner/worktree-guard-hook.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Claude Code PreToolUse hook entrypoint.
+ *
+ * Invocation:
+ *   node dist/spawner/worktree-guard-hook.js [worktree-root]
+ *
+ * Environment:
+ *   MULTICLAUDE_WORKTREE  — absolute path to the worker's worktree root
+ *   MULTICLAUDE_TASK_ID   — task identifier (used in violation log)
+ *
+ * The worktree root can also be supplied as the first positional argument
+ * (argv[2]) for contexts where env vars are unavailable.
+ *
+ * Reads a Claude Code hook JSON payload from stdin, extracts the target
+ * file path for Write / Edit / Read / NotebookEdit tool calls, and denies
+ * the tool invocation when the path falls outside the worktree.
+ *
+ * Deny signal: exits with code 2 and writes {"reason": "..."} to stdout.
+ * On deny, also appends a structured line to .claude/boundary-violations.log
+ * inside the worktree so violations are observable.
+ */
+
+import { readFileSync, appendFileSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { isPathInWorktree } from './worktree-guard.js'
+
+interface HookPayload {
+  session_id?: string
+  transcript_path?: string
+  // Flat format (most common)
+  tool_name?: string
+  tool_input?: Record<string, unknown>
+  // Nested format (alternative)
+  tool_use?: {
+    name: string
+    input: Record<string, unknown>
+  }
+}
+
+interface ViolationEntry {
+  timestamp: string
+  tool: string
+  path: string
+  taskId: string
+}
+
+function extractTargetPaths(toolName: string, toolInput: Record<string, unknown>): string[] {
+  switch (toolName) {
+    case 'Write':
+    case 'Edit':
+    case 'Read':
+      if (typeof toolInput.file_path === 'string') return [toolInput.file_path]
+      break
+    case 'NotebookEdit':
+      if (typeof toolInput.notebook_path === 'string') return [toolInput.notebook_path]
+      break
+  }
+  return []
+}
+
+function logViolation(worktreeRoot: string, entry: ViolationEntry): void {
+  try {
+    const logDir = join(worktreeRoot, '.claude')
+    mkdirSync(logDir, { recursive: true })
+    appendFileSync(join(logDir, 'boundary-violations.log'), JSON.stringify(entry) + '\n', 'utf-8')
+  } catch {
+    // Never let log failures prevent the deny from propagating.
+  }
+}
+
+function deny(reason: string): never {
+  process.stdout.write(JSON.stringify({ reason }) + '\n')
+  process.exit(2)
+}
+
+function main(): void {
+  const worktreeRoot = process.env.MULTICLAUDE_WORKTREE ?? process.argv[2]
+  const taskId = process.env.MULTICLAUDE_TASK_ID ?? 'unknown'
+
+  if (!worktreeRoot) {
+    // Not running in a worker context — allow everything through.
+    process.exit(0)
+  }
+
+  let raw: string
+  try {
+    raw = readFileSync('/dev/stdin', 'utf-8')
+  } catch {
+    // Can't read stdin; allow through rather than blocking blindly.
+    process.exit(0)
+  }
+
+  let payload: HookPayload
+  try {
+    payload = JSON.parse(raw) as HookPayload
+  } catch {
+    process.exit(0)
+  }
+
+  // Normalise both payload shapes into a single (toolName, toolInput) pair.
+  const toolName = payload.tool_name ?? payload.tool_use?.name ?? ''
+  const toolInput = payload.tool_input ?? payload.tool_use?.input ?? {}
+
+  const paths = extractTargetPaths(toolName, toolInput)
+
+  for (const targetPath of paths) {
+    if (!isPathInWorktree(worktreeRoot, targetPath)) {
+      logViolation(worktreeRoot, {
+        timestamp: new Date().toISOString(),
+        tool: toolName,
+        path: targetPath,
+        taskId,
+      })
+      deny(
+        `Boundary violation: ${toolName} attempted to access "${targetPath}" which is outside the assigned worktree "${worktreeRoot}". Worker agents must stay within their worktree.`,
+      )
+    }
+  }
+
+  process.exit(0)
+}
+
+main()

--- a/src/spawner/worktree-guard.ts
+++ b/src/spawner/worktree-guard.ts
@@ -1,0 +1,64 @@
+import { realpathSync } from 'fs'
+import { resolve, dirname, basename, join } from 'path'
+
+/**
+ * Resolves a path to its real (symlink-free) path.
+ * Unlike realpathSync, handles paths that do not exist yet by walking up
+ * to the nearest existing ancestor, resolving that, then re-appending
+ * the non-existent tail segments. This correctly handles /tmp → /private/tmp
+ * on macOS for paths that haven't been created yet.
+ */
+function resolveWithFallback(p: string): string {
+  const normalized = resolve(p)
+  try {
+    return realpathSync(normalized)
+  } catch {
+    // Non-existent path: resolve the nearest existing ancestor.
+    const parts: string[] = []
+    let current = normalized
+    while (true) {
+      try {
+        const real = realpathSync(current)
+        return parts.length === 0 ? real : join(real, ...parts.reverse())
+      } catch {
+        const parent = dirname(current)
+        if (parent === current) break // reached filesystem root
+        parts.push(basename(current))
+        current = parent
+      }
+    }
+    return normalized
+  }
+}
+
+/**
+ * Returns true when candidatePath is inside worktreeRoot.
+ *
+ * Handles:
+ * - Relative paths (resolved via resolve())
+ * - ".." traversal attacks
+ * - Symlinks on both sides (e.g. /tmp → /private/tmp on macOS)
+ * - Paths that do not exist yet (Write to a new file)
+ * - Case-insensitive macOS filesystems (compares lowercased resolved paths)
+ *
+ * Denies (returns false) by default when the answer is unclear or an
+ * exception occurs.
+ */
+export function isPathInWorktree(worktreeRoot: string, candidatePath: string): boolean {
+  try {
+    // Worktree root must exist — if realpathSync throws, deny.
+    const resolvedRoot = realpathSync(resolve(worktreeRoot))
+    const resolvedCandidate = resolveWithFallback(resolve(candidatePath))
+
+    // Normalise for case-insensitive filesystems (macOS HFS+/APFS default).
+    const rootLower = resolvedRoot.toLowerCase()
+    const candidateLower = resolvedCandidate.toLowerCase()
+
+    // The candidate must equal the root or be strictly inside it.
+    // Appending '/' prevents prefix-collision: /tmp/mc-abc would otherwise
+    // falsely match /tmp/mc-abcdef.
+    return candidateLower === rootLower || candidateLower.startsWith(rootLower + '/')
+  } catch {
+    return false
+  }
+}

--- a/tests/boundary-e2e.test.ts
+++ b/tests/boundary-e2e.test.ts
@@ -1,0 +1,313 @@
+/**
+ * End-to-end test: a run leaves the main checkout untouched.
+ *
+ * Issue #109, acceptance criterion 1. Follows the pattern in git-pipeline.e2e.test.ts.
+ *
+ * This test:
+ * 1. Creates a temp git repo with committed files
+ * 2. Spawns a worktree-backed task (via handleSpawnWorker, same as the real flow)
+ * 3. Simulates the PreToolUse hook being fired for Write and Read calls targeting the
+ *    main checkout — using the exact hook subprocess + env that a real worker launch
+ *    would use, rather than shelling out to a full Claude binary
+ * 4. Asserts:
+ *    (a) main checkout working tree is byte-identical and git status is unchanged
+ *    (b) the attempts were denied (hook exits 2, stdout carries {"reason": "..."})
+ *    (c) the denial is recorded in .claude/boundary-violations.log in the worktree
+ *
+ * Regression case: two paths that share a basename but differ only by directory
+ * (`app/_layout.tsx` vs `app/(tabs)/_layout.tsx`) — a guard that tests basename
+ * alone would pass the first and wrongly allow the second.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { execSync } from 'child_process'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs'
+import { createHash } from 'crypto'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type Database from 'better-sqlite3'
+
+// ── Stubs ──────────────────────────────────────────────────────────────────────
+
+// tmux is stubbed: tests run outside a tmux session and handleSpawnWorker must not
+// attempt to spin one up.
+vi.mock('../src/spawner/tmux.js', () => ({
+  killTmuxWindow: vi.fn(),
+  reapStaleWindows: vi.fn(),
+  ensureTmuxSession: vi.fn(() => 'multiclaude'),
+  captureTmuxPane: vi.fn(() => ''),
+  spawnTmuxWorker: vi.fn(),
+  createTmuxWindow: vi.fn(() => '@1'),
+}))
+
+// ── Imports after mocks ────────────────────────────────────────────────────────
+
+import { createDb, closeDb } from '../src/server/state/db.js'
+import { createTask, getTask } from '../src/server/state/tasks.js'
+import { upsertProject } from '../src/server/state/projects.js'
+import { createRun } from '../src/server/state/runs.js'
+import { handleSpawnWorker } from '../src/server/tools/orchestrator.js'
+import { buildWorkerSettings, resolveHookCommand } from '../src/spawner/index.js'
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function initRepo(repoPath: string): void {
+  execSync('git init -b main', { cwd: repoPath })
+  execSync('git config user.email "e2e@test.com"', { cwd: repoPath })
+  execSync('git config user.name "E2E Test"', { cwd: repoPath })
+  writeFileSync(join(repoPath, 'README.md'), '# project\n')
+  execSync('git add . && git commit -m "init"', { cwd: repoPath })
+}
+
+/**
+ * Writes settings.local.json to the worktree's .claude/ directory exactly as
+ * the real spawner (spawnWorker in src/spawner/index.ts) would before launching
+ * a Claude subprocess. This registers the boundary-guard PreToolUse hook.
+ */
+function writeWorkerSettings(worktreePath: string, repoPath: string): void {
+  const claudeDir = join(worktreePath, '.claude')
+  mkdirSync(claudeDir, { recursive: true })
+  writeFileSync(
+    join(claudeDir, 'settings.local.json'),
+    JSON.stringify(buildWorkerSettings({ worktreePath, repoPath }), null, 2),
+  )
+}
+
+/**
+ * Invokes the boundary-guard PreToolUse hook the way a real worker launch would:
+ * - Uses resolveHookCommand() — the exact same function that buildWorkerSettings
+ *   embeds into the settings.local.json hooks entry
+ * - Sets MULTICLAUDE_WORKTREE and MULTICLAUDE_TASK_ID in the subprocess env
+ * - Pipes the JSON payload on stdin (how Claude Code fires a PreToolUse hook)
+ */
+function invokeGuardHook(
+  payload: object,
+  worktreePath: string,
+  taskId: string,
+): { exitCode: number; stdout: string } {
+  const hookCmd = resolveHookCommand()
+  const input = JSON.stringify(payload).replace(/'/g, "'\\''")
+  try {
+    const stdout = execSync(`echo '${input}' | ${hookCmd}`, {
+      encoding: 'utf-8',
+      env: { ...process.env, MULTICLAUDE_WORKTREE: worktreePath, MULTICLAUDE_TASK_ID: taskId },
+      timeout: 15000,
+    })
+    return { exitCode: 0, stdout }
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; status?: number }
+    return { exitCode: e.status ?? 1, stdout: e.stdout ?? '' }
+  }
+}
+
+/**
+ * SHA-256 over every non-.git file in a directory, sorted by path.
+ * Used to detect any mutation to the main checkout's working tree.
+ */
+function hashWorkingTree(dir: string): string {
+  const hash = createHash('sha256')
+  const files = execSync(`find "${dir}" -type f ! -path "*/.git/*" | sort`, {
+    encoding: 'utf-8',
+  })
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+  for (const f of files) {
+    hash.update(f)
+    hash.update(readFileSync(f))
+  }
+  return hash.digest('hex')
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('boundary guard e2e: main checkout stays untouched', () => {
+  let db: Database.Database
+  let repoPath: string
+  let worktreesToClean: string[]
+
+  beforeEach(() => {
+    repoPath = mkdtempSync(join(tmpdir(), 'mc-boundary-e2e-'))
+    worktreesToClean = []
+    initRepo(repoPath)
+    db = createDb(':memory:')
+  })
+
+  afterEach(() => {
+    closeDb(db)
+    for (const p of worktreesToClean) {
+      rmSync(p, { recursive: true, force: true })
+    }
+    rmSync(repoPath, { recursive: true, force: true })
+  })
+
+  it(
+    'Write and Read to main checkout are denied; working tree byte-identical before vs after',
+    async () => {
+      // Commit a sensitive file into the main checkout
+      writeFileSync(join(repoPath, 'sensitive.ts'), 'export const apiKey = "secret"\n')
+      execSync('git add . && git commit -m "add sensitive"', { cwd: repoPath })
+
+      // Set up a run + task, then create the worktree (same pattern as git-pipeline.e2e.test.ts)
+      const project = upsertProject(db, { name: 'boundary-test', cwd: repoPath })
+      const run = createRun(db, { project_id: project.id, title: 'Boundary E2E Run' })
+      createTask(db, { id: 'task-boundary', title: 'Boundary task', run_id: run.id })
+
+      const spawnResult = await handleSpawnWorker(db, 'task-boundary', 'w-boundary', {
+        cwd: repoPath,
+      })
+      expect(spawnResult.ok).toBe(true)
+
+      const task = getTask(db, 'task-boundary')!
+      expect(task.worktree_path).toBeTruthy()
+      worktreesToClean.push(task.worktree_path!)
+
+      // Write settings.local.json into the worktree — exactly what the real spawner does
+      // before launching the Claude subprocess. This registers the boundary-guard hook.
+      writeWorkerSettings(task.worktree_path!, repoPath)
+
+      // ── Snapshot the main checkout BEFORE any hook invocations ────────────────
+      const hashBefore = hashWorkingTree(repoPath)
+      const statusBefore = execSync('git status --porcelain', { cwd: repoPath, encoding: 'utf-8' })
+
+      // ── Simulate a Write tool call targeting the main checkout ────────────────
+      const writeResult = invokeGuardHook(
+        { tool_name: 'Write', tool_input: { file_path: join(repoPath, 'sensitive.ts'), content: 'hacked!' } },
+        task.worktree_path!,
+        'task-boundary',
+      )
+      // (b) Write must be denied — hook exits 2 and emits a reason JSON
+      expect(writeResult.exitCode).toBe(2)
+      const writeDeny = JSON.parse(writeResult.stdout.trim())
+      expect(writeDeny).toHaveProperty('reason')
+      expect(typeof writeDeny.reason).toBe('string')
+      expect(writeDeny.reason.length).toBeGreaterThan(0)
+
+      // ── Simulate a Read tool call targeting the main checkout ─────────────────
+      const readResult = invokeGuardHook(
+        { tool_name: 'Read', tool_input: { file_path: join(repoPath, 'sensitive.ts') } },
+        task.worktree_path!,
+        'task-boundary',
+      )
+      // (b) Read must also be denied — the guard blocks all out-of-tree file access
+      expect(readResult.exitCode).toBe(2)
+
+      // ── (a) Main checkout is byte-identical after the denied attempts ──────────
+      const hashAfter = hashWorkingTree(repoPath)
+      const statusAfter = execSync('git status --porcelain', {
+        cwd: repoPath,
+        encoding: 'utf-8',
+      })
+      expect(hashAfter).toBe(hashBefore)
+      expect(statusAfter).toBe(statusBefore)
+
+      // ── (c) Denial is recorded in the worktree's operator-visible log ──────────
+      const logPath = join(task.worktree_path!, '.claude', 'boundary-violations.log')
+      expect(existsSync(logPath)).toBe(true)
+      const logLines = readFileSync(logPath, 'utf-8').trim().split('\n').filter(Boolean)
+      // At minimum the Write violation is logged; Read also produces an entry
+      expect(logLines.length).toBeGreaterThanOrEqual(1)
+      const firstEntry = JSON.parse(logLines[0])
+      expect(firstEntry.tool).toBe('Write')
+      expect(firstEntry.path).toBe(join(repoPath, 'sensitive.ts'))
+      expect(firstEntry.taskId).toBe('task-boundary')
+      expect(typeof firstEntry.timestamp).toBe('string')
+    },
+    30000,
+  )
+
+  it(
+    'regression: guard rejects both app/_layout.tsx and app/(tabs)/_layout.tsx — basename-only guard fails this test',
+    async () => {
+      // Commit two files with the SAME basename but different directories into the main checkout.
+      // The incident that motivated this test: a worker modified app/(tabs)/_layout.tsx
+      // when it was supposed to stay in app/_layout.tsx. A guard that checks basename
+      // alone cannot distinguish them.
+      mkdirSync(join(repoPath, 'app', '(tabs)'), { recursive: true })
+      writeFileSync(join(repoPath, 'app', '_layout.tsx'), 'export default function Root() {}\n')
+      writeFileSync(
+        join(repoPath, 'app', '(tabs)', '_layout.tsx'),
+        'export default function Tabs() {}\n',
+      )
+      execSync('git add . && git commit -m "add layouts"', { cwd: repoPath })
+
+      // Create run + task + worktree
+      const project = upsertProject(db, { name: 'basename-regression', cwd: repoPath })
+      const run = createRun(db, { project_id: project.id, title: 'Basename Regression' })
+      createTask(db, { id: 'task-basename', title: 'Basename regression task', run_id: run.id })
+
+      const spawnResult = await handleSpawnWorker(db, 'task-basename', 'w-basename', {
+        cwd: repoPath,
+      })
+      expect(spawnResult.ok).toBe(true)
+
+      const task = getTask(db, 'task-basename')!
+      worktreesToClean.push(task.worktree_path!)
+
+      // Seed the worktree with the same directory structure — files the worker legitimately owns.
+      // A basename-only guard would see these and wrongly allow writes to the same-named files
+      // in the main checkout.
+      mkdirSync(join(task.worktree_path!, 'app', '(tabs)'), { recursive: true })
+      writeFileSync(
+        join(task.worktree_path!, 'app', '_layout.tsx'),
+        'export default function Root() {}\n',
+      )
+      writeFileSync(
+        join(task.worktree_path!, 'app', '(tabs)', '_layout.tsx'),
+        'export default function Tabs() {}\n',
+      )
+
+      // Attempt 1: Write to mainCheckout/app/_layout.tsx → must be denied
+      const r1 = invokeGuardHook(
+        {
+          tool_name: 'Write',
+          tool_input: { file_path: join(repoPath, 'app', '_layout.tsx'), content: 'hacked!' },
+        },
+        task.worktree_path!,
+        'task-basename',
+      )
+      expect(r1.exitCode).toBe(2)
+
+      // Attempt 2: Write to mainCheckout/app/(tabs)/_layout.tsx → must also be denied.
+      // A basename-only guard finds worktree/app/(tabs)/_layout.tsx and wrongly allows this.
+      const r2 = invokeGuardHook(
+        {
+          tool_name: 'Write',
+          tool_input: {
+            file_path: join(repoPath, 'app', '(tabs)', '_layout.tsx'),
+            content: 'hacked!',
+          },
+        },
+        task.worktree_path!,
+        'task-basename',
+      )
+      expect(r2.exitCode).toBe(2)
+
+      // Sanity: writes inside the worktree are still allowed
+      const r3 = invokeGuardHook(
+        {
+          tool_name: 'Write',
+          tool_input: {
+            file_path: join(task.worktree_path!, 'app', '_layout.tsx'),
+            content: 'safe update',
+          },
+        },
+        task.worktree_path!,
+        'task-basename',
+      )
+      expect(r3.exitCode).toBe(0)
+
+      // Sanity: reads inside the worktree are allowed
+      const r4 = invokeGuardHook(
+        {
+          tool_name: 'Read',
+          tool_input: { file_path: join(task.worktree_path!, 'app', '(tabs)', '_layout.tsx') },
+        },
+        task.worktree_path!,
+        'task-basename',
+      )
+      expect(r4.exitCode).toBe(0)
+    },
+    30000,
+  )
+})

--- a/tests/spawner/index.test.ts
+++ b/tests/spawner/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildWorkerMcpConfig, buildWorkerArgs, buildWorkerEnv, writeWorkerMcpConfig } from '../../src/spawner/index.js'
+import { buildWorkerMcpConfig, buildWorkerArgs, buildWorkerEnv, buildWorkerSettings, resolveHookCommand, writeWorkerMcpConfig } from '../../src/spawner/index.js'
 import type { SpawnConfig } from '../../src/spawner/index.js'
 
 describe('spawner', () => {
@@ -86,6 +86,46 @@ describe('spawner', () => {
   it('buildWorkerEnv sets MULTICLAUDE_AGENT_ID', () => {
     const env = buildWorkerEnv('w-task-1')
     expect(env['MULTICLAUDE_AGENT_ID']).toBe('w-task-1')
+  })
+
+  it('buildWorkerEnv sets MULTICLAUDE_WORKTREE from isolation.worktreePath', () => {
+    const env = buildWorkerEnv('w-task-1', {
+      worktreePath: '/tmp/mc-task-1-abcdef',
+      gitDir: '/repos/.git/worktrees/mc-task-1-abcdef',
+    })
+    expect(env['MULTICLAUDE_WORKTREE']).toBe('/tmp/mc-task-1-abcdef')
+  })
+
+  it('buildWorkerEnv sets MULTICLAUDE_WORKTREE from opts.worktreePath when no isolation', () => {
+    const env = buildWorkerEnv('w-task-1', undefined, { worktreePath: '/tmp/mc-task-fallback' })
+    expect(env['MULTICLAUDE_WORKTREE']).toBe('/tmp/mc-task-fallback')
+  })
+
+  it('buildWorkerEnv omits MULTICLAUDE_WORKTREE when neither isolation nor opts provided', () => {
+    const saved = process.env.MULTICLAUDE_WORKTREE
+    delete process.env.MULTICLAUDE_WORKTREE
+    try {
+      const env = buildWorkerEnv('w-task-1')
+      expect(env['MULTICLAUDE_WORKTREE']).toBeUndefined()
+    } finally {
+      if (saved !== undefined) process.env.MULTICLAUDE_WORKTREE = saved
+    }
+  })
+
+  it('buildWorkerEnv sets MULTICLAUDE_TASK_ID from opts.taskId', () => {
+    const env = buildWorkerEnv('w-task-1', undefined, { taskId: 'my-task-123' })
+    expect(env['MULTICLAUDE_TASK_ID']).toBe('my-task-123')
+  })
+
+  it('buildWorkerEnv omits MULTICLAUDE_TASK_ID when not provided', () => {
+    const saved = process.env.MULTICLAUDE_TASK_ID
+    delete process.env.MULTICLAUDE_TASK_ID
+    try {
+      const env = buildWorkerEnv('w-task-1')
+      expect(env['MULTICLAUDE_TASK_ID']).toBeUndefined()
+    } finally {
+      if (saved !== undefined) process.env.MULTICLAUDE_TASK_ID = saved
+    }
   })
 
   it('buildWorkerArgs passes --model with correct model ID for sonnet (default)', () => {
@@ -234,5 +274,82 @@ describe('spawner', () => {
     const args = buildWorkerArgs(cfg)
     expect(args).toContain('--effort')
     expect(args[args.indexOf('--effort') + 1]).toBe('xhigh')
+  })
+})
+
+describe('buildWorkerSettings', () => {
+  it('scopes Write permission to the worktree path', () => {
+    const settings = buildWorkerSettings({ worktreePath: '/tmp/mc-test-worktree' }) as any
+    expect(settings.permissions.allow).toContain('Write(/tmp/mc-test-worktree/**)')
+  })
+
+  it('scopes Edit permission to the worktree path', () => {
+    const settings = buildWorkerSettings({ worktreePath: '/tmp/mc-test-worktree' }) as any
+    expect(settings.permissions.allow).toContain('Edit(/tmp/mc-test-worktree/**)')
+  })
+
+  it('keeps Read(*) as unrestricted (hook enforces boundary)', () => {
+    const settings = buildWorkerSettings({ worktreePath: '/tmp/mc-test-worktree' }) as any
+    expect(settings.permissions.allow).toContain('Read(*)')
+  })
+
+  it('keeps Bash(*) as unrestricted (cannot scope by path via globs)', () => {
+    const settings = buildWorkerSettings({ worktreePath: '/tmp/mc-test-worktree' }) as any
+    expect(settings.permissions.allow).toContain('Bash(*)')
+  })
+
+  it('does not include blanket Write(*) or Edit(*)', () => {
+    const settings = buildWorkerSettings({ worktreePath: '/tmp/mc-test-worktree' }) as any
+    expect(settings.permissions.allow).not.toContain('Write(*)')
+    expect(settings.permissions.allow).not.toContain('Edit(*)')
+  })
+
+  it('includes all required worker MCP tools', () => {
+    const settings = buildWorkerSettings({ worktreePath: '/tmp/mc-test-worktree' }) as any
+    expect(settings.permissions.allow).toContain('mcp__multiclaude-worker__get_my_task')
+    expect(settings.permissions.allow).toContain('mcp__multiclaude-worker__report_progress')
+    expect(settings.permissions.allow).toContain('mcp__multiclaude-worker__report_done')
+    expect(settings.permissions.allow).toContain('mcp__multiclaude-worker__report_blocked')
+  })
+
+  it('adds deny rules for repoPath when provided', () => {
+    const settings = buildWorkerSettings({
+      worktreePath: '/tmp/mc-test-worktree',
+      repoPath: '/Users/alice/myproject',
+    }) as any
+    expect(settings.permissions.deny).toBeDefined()
+    expect(settings.permissions.deny).toContain('Write(/Users/alice/myproject/**)')
+    expect(settings.permissions.deny).toContain('Edit(/Users/alice/myproject/**)')
+  })
+
+  it('omits deny key when no repoPath is provided', () => {
+    const settings = buildWorkerSettings({ worktreePath: '/tmp/mc-test-worktree' }) as any
+    expect(settings.permissions.deny).toBeUndefined()
+  })
+
+  it('registers a PreToolUse hook entry', () => {
+    const settings = buildWorkerSettings({ worktreePath: '/tmp/mc-test-worktree' }) as any
+    expect(settings.hooks).toBeDefined()
+    expect(settings.hooks.PreToolUse).toBeDefined()
+    expect(Array.isArray(settings.hooks.PreToolUse)).toBe(true)
+    expect(settings.hooks.PreToolUse.length).toBeGreaterThan(0)
+    const entry = settings.hooks.PreToolUse[0]
+    expect(entry.matcher).toBe('.*')
+    expect(entry.hooks[0].type).toBe('command')
+    expect(typeof entry.hooks[0].command).toBe('string')
+    expect(entry.hooks[0].command.length).toBeGreaterThan(0)
+  })
+})
+
+describe('resolveHookCommand', () => {
+  it('returns a non-empty string', () => {
+    const cmd = resolveHookCommand()
+    expect(typeof cmd).toBe('string')
+    expect(cmd.length).toBeGreaterThan(0)
+  })
+
+  it('command references the worktree-guard-hook file', () => {
+    const cmd = resolveHookCommand()
+    expect(cmd).toContain('worktree-guard-hook')
   })
 })

--- a/tests/spawner/worktree-guard.test.ts
+++ b/tests/spawner/worktree-guard.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, symlinkSync, rmSync, readFileSync, existsSync } from 'fs'
+import { join, resolve } from 'path'
+import { tmpdir } from 'os'
+import { execSync } from 'child_process'
+import { isPathInWorktree } from '../../src/spawner/worktree-guard.js'
+
+// ---------------------------------------------------------------------------
+// isPathInWorktree — pure predicate
+// ---------------------------------------------------------------------------
+
+describe('isPathInWorktree', () => {
+  let worktree: string
+
+  beforeEach(() => {
+    worktree = mkdtempSync(join(tmpdir(), 'mc-guard-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(worktree, { recursive: true, force: true })
+  })
+
+  it('allows an existing file directly inside the worktree', () => {
+    expect(isPathInWorktree(worktree, join(worktree, 'file.ts'))).toBe(true)
+  })
+
+  it('allows an existing file in a sub-directory', () => {
+    const sub = join(worktree, 'src', 'foo')
+    mkdirSync(sub, { recursive: true })
+    expect(isPathInWorktree(worktree, join(sub, 'bar.ts'))).toBe(true)
+  })
+
+  it('allows the worktree root itself', () => {
+    expect(isPathInWorktree(worktree, worktree)).toBe(true)
+  })
+
+  it('denies a path outside the worktree', () => {
+    expect(isPathInWorktree(worktree, '/etc/passwd')).toBe(false)
+  })
+
+  it('denies a path that is a sibling of the worktree', () => {
+    const sibling = worktree + '-sibling'
+    expect(isPathInWorktree(worktree, sibling)).toBe(false)
+  })
+
+  it('denies a path that is the parent of the worktree', () => {
+    expect(isPathInWorktree(worktree, tmpdir())).toBe(false)
+  })
+
+  // .. traversal ---------------------------------------------------------------
+
+  it('denies a path that uses .. to escape the worktree', () => {
+    const evil = join(worktree, '..', 'escape.ts')
+    expect(isPathInWorktree(worktree, evil)).toBe(false)
+  })
+
+  it('denies a deeply nested .. traversal that escapes', () => {
+    const evil = join(worktree, 'src', 'foo', '..', '..', '..', 'escape.ts')
+    expect(isPathInWorktree(worktree, evil)).toBe(false)
+  })
+
+  it('allows a path with .. that still stays inside the worktree', () => {
+    const safe = join(worktree, 'src', '..', 'file.ts')
+    expect(isPathInWorktree(worktree, safe)).toBe(true)
+  })
+
+  // Non-existent paths (Write to new file) ------------------------------------
+
+  it('allows a non-existent file inside the worktree', () => {
+    const newFile = join(worktree, 'does-not-exist.ts')
+    expect(isPathInWorktree(worktree, newFile)).toBe(true)
+  })
+
+  it('allows a non-existent nested path inside the worktree', () => {
+    const newFile = join(worktree, 'new', 'dir', 'file.ts')
+    expect(isPathInWorktree(worktree, newFile)).toBe(true)
+  })
+
+  it('denies a non-existent file that is outside the worktree', () => {
+    expect(isPathInWorktree(worktree, '/tmp/mc-OTHER-worktree/file.ts')).toBe(false)
+  })
+
+  // Relative paths -------------------------------------------------------------
+
+  it('allows a relative path that resolves to inside the worktree', () => {
+    // chdir-based relative paths are tricky; just test resolve() semantics
+    const relative = worktree + '/./src/../file.ts'
+    expect(isPathInWorktree(worktree, relative)).toBe(true)
+  })
+
+  // Symlinks -------------------------------------------------------------------
+
+  it('resolves symlinks on the worktree root side', () => {
+    // Create a symlink pointing to the real worktree
+    const link = worktree + '-link'
+    symlinkSync(worktree, link)
+    try {
+      // The candidate uses the real path, the root is the symlink
+      expect(isPathInWorktree(link, join(worktree, 'file.ts'))).toBe(true)
+    } finally {
+      rmSync(link)
+    }
+  })
+
+  it('resolves symlinks on the candidate path side', () => {
+    const link = worktree + '-link'
+    symlinkSync(worktree, link)
+    try {
+      // The root is the real path, the candidate goes through the symlink
+      expect(isPathInWorktree(worktree, join(link, 'file.ts'))).toBe(true)
+    } finally {
+      rmSync(link)
+    }
+  })
+
+  it('handles /tmp -> /private/tmp symlink on macOS (or identity on Linux)', () => {
+    // On macOS /tmp is a symlink to /private/tmp. Create worktree under /tmp
+    // and verify a /private/tmp path still matches (or vice-versa on Linux).
+    const tmpWorktree = mkdtempSync('/tmp/mc-guard-sym-')
+    try {
+      const insidePath = join(tmpWorktree, 'file.ts')
+      expect(isPathInWorktree(tmpWorktree, insidePath)).toBe(true)
+    } finally {
+      rmSync(tmpWorktree, { recursive: true, force: true })
+    }
+  })
+
+  it('denies when worktree root does not exist (deny by default)', () => {
+    expect(isPathInWorktree('/nonexistent-worktree-xyz', '/nonexistent-worktree-xyz/file.ts')).toBe(false)
+  })
+
+  // Case-insensitive macOS filesystems -----------------------------------------
+
+  it('allows path with different case when the real filesystem resolves them equally', () => {
+    // On a case-insensitive filesystem, /TMP/foo == /tmp/foo. We test with
+    // an uppercase version of the worktree path; on macOS this will resolve
+    // to the same real path, so the guard should allow it.
+    // On case-sensitive Linux, this will denote a different path and should
+    // also work correctly (denying it, since we compare lower-cased resolved paths).
+    const upperWorktree = worktree.toUpperCase()
+    const insidePath = join(worktree, 'file.ts')
+    // We just assert the function doesn't throw — the exact result depends on fs.
+    expect(typeof isPathInWorktree(upperWorktree, insidePath)).toBe('boolean')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Hook entrypoint — stdin/stdout/exit-code tests
+// ---------------------------------------------------------------------------
+
+function runHook(
+  payload: object,
+  env: Record<string, string> = {},
+): { exitCode: number; stdout: string; stderr: string } {
+  // Invoke the compiled hook script using tsx (for TS source in tests)
+  const hookPath = resolve(
+    new URL('../../src/spawner/worktree-guard-hook.ts', import.meta.url).pathname,
+  )
+  const input = JSON.stringify(payload)
+  try {
+    const stdout = execSync(`echo '${input.replace(/'/g, "'\\''")}' | npx tsx ${hookPath}`, {
+      encoding: 'utf-8',
+      env: { ...process.env, ...env },
+      timeout: 10000,
+    })
+    return { exitCode: 0, stdout, stderr: '' }
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; stderr?: string; status?: number }
+    return {
+      exitCode: e.status ?? 1,
+      stdout: e.stdout ?? '',
+      stderr: e.stderr ?? '',
+    }
+  }
+}
+
+describe('worktree-guard hook entrypoint', () => {
+  let worktree: string
+
+  beforeEach(() => {
+    worktree = mkdtempSync(join(tmpdir(), 'mc-hook-test-'))
+    mkdirSync(join(worktree, '.claude'), { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(worktree, { recursive: true, force: true })
+  })
+
+  // Write tool -----------------------------------------------------------------
+
+  it('exits 0 for Write tool with file_path inside worktree', () => {
+    const result = runHook(
+      { tool_name: 'Write', tool_input: { file_path: join(worktree, 'new.ts'), content: '' } },
+      { MULTICLAUDE_WORKTREE: worktree, MULTICLAUDE_TASK_ID: 'test-task' },
+    )
+    expect(result.exitCode).toBe(0)
+  })
+
+  it('exits 2 for Write tool with file_path outside worktree', () => {
+    const result = runHook(
+      { tool_name: 'Write', tool_input: { file_path: '/etc/passwd', content: 'bad' } },
+      { MULTICLAUDE_WORKTREE: worktree, MULTICLAUDE_TASK_ID: 'test-task' },
+    )
+    expect(result.exitCode).toBe(2)
+  })
+
+  it('writes a reason JSON on deny for Write', () => {
+    const result = runHook(
+      { tool_name: 'Write', tool_input: { file_path: '/etc/passwd', content: 'bad' } },
+      { MULTICLAUDE_WORKTREE: worktree, MULTICLAUDE_TASK_ID: 'test-task' },
+    )
+    expect(result.exitCode).toBe(2)
+    const parsed = JSON.parse(result.stdout.trim())
+    expect(parsed).toHaveProperty('reason')
+    expect(typeof parsed.reason).toBe('string')
+    expect(parsed.reason.length).toBeGreaterThan(0)
+  })
+
+  // Edit tool ------------------------------------------------------------------
+
+  it('exits 0 for Edit tool inside worktree', () => {
+    const result = runHook(
+      {
+        tool_name: 'Edit',
+        tool_input: { file_path: join(worktree, 'src.ts'), old_string: 'a', new_string: 'b' },
+      },
+      { MULTICLAUDE_WORKTREE: worktree },
+    )
+    expect(result.exitCode).toBe(0)
+  })
+
+  it('exits 2 for Edit tool outside worktree', () => {
+    const result = runHook(
+      { tool_name: 'Edit', tool_input: { file_path: '/usr/local/lib/evil.ts' } },
+      { MULTICLAUDE_WORKTREE: worktree },
+    )
+    expect(result.exitCode).toBe(2)
+  })
+
+  // Read tool ------------------------------------------------------------------
+
+  it('exits 0 for Read tool inside worktree', () => {
+    const result = runHook(
+      { tool_name: 'Read', tool_input: { file_path: join(worktree, 'README.md') } },
+      { MULTICLAUDE_WORKTREE: worktree },
+    )
+    expect(result.exitCode).toBe(0)
+  })
+
+  it('exits 2 for Read tool outside worktree', () => {
+    const result = runHook(
+      { tool_name: 'Read', tool_input: { file_path: '/etc/hosts' } },
+      { MULTICLAUDE_WORKTREE: worktree },
+    )
+    expect(result.exitCode).toBe(2)
+  })
+
+  // NotebookEdit tool ----------------------------------------------------------
+
+  it('exits 0 for NotebookEdit with notebook_path inside worktree', () => {
+    const result = runHook(
+      { tool_name: 'NotebookEdit', tool_input: { notebook_path: join(worktree, 'nb.ipynb') } },
+      { MULTICLAUDE_WORKTREE: worktree },
+    )
+    expect(result.exitCode).toBe(0)
+  })
+
+  it('exits 2 for NotebookEdit with notebook_path outside worktree', () => {
+    const result = runHook(
+      { tool_name: 'NotebookEdit', tool_input: { notebook_path: '/tmp/evil.ipynb' } },
+      { MULTICLAUDE_WORKTREE: worktree },
+    )
+    expect(result.exitCode).toBe(2)
+  })
+
+  // Unknown / untracked tools -------------------------------------------------
+
+  it('exits 0 for an untracked tool (no path to check)', () => {
+    const result = runHook(
+      { tool_name: 'Bash', tool_input: { command: 'echo hello' } },
+      { MULTICLAUDE_WORKTREE: worktree },
+    )
+    expect(result.exitCode).toBe(0)
+  })
+
+  // No worktree configured ----------------------------------------------------
+
+  it('exits 0 when MULTICLAUDE_WORKTREE is not set (allow through)', () => {
+    const result = runHook(
+      { tool_name: 'Write', tool_input: { file_path: '/etc/passwd', content: 'bad' } },
+      {}, // no MULTICLAUDE_WORKTREE
+    )
+    expect(result.exitCode).toBe(0)
+  })
+
+  // Violation logging ----------------------------------------------------------
+
+  it('appends a log line to .claude/boundary-violations.log on deny', () => {
+    const logFile = join(worktree, '.claude', 'boundary-violations.log')
+    runHook(
+      { tool_name: 'Write', tool_input: { file_path: '/etc/shadow', content: 'bad' } },
+      { MULTICLAUDE_WORKTREE: worktree, MULTICLAUDE_TASK_ID: 'task-abc' },
+    )
+    expect(existsSync(logFile)).toBe(true)
+    const log = readFileSync(logFile, 'utf-8').trim()
+    const entry = JSON.parse(log.split('\n')[0])
+    expect(entry.tool).toBe('Write')
+    expect(entry.path).toBe('/etc/shadow')
+    expect(entry.taskId).toBe('task-abc')
+    expect(typeof entry.timestamp).toBe('string')
+  })
+
+  it('does not create log file when access is allowed', () => {
+    const logFile = join(worktree, '.claude', 'boundary-violations.log')
+    runHook(
+      { tool_name: 'Write', tool_input: { file_path: join(worktree, 'safe.ts'), content: '' } },
+      { MULTICLAUDE_WORKTREE: worktree, MULTICLAUDE_TASK_ID: 'task-abc' },
+    )
+    expect(existsSync(logFile)).toBe(false)
+  })
+
+  // Nested tool_use format (alternative payload shape) ------------------------
+
+  it('handles nested tool_use format for Write', () => {
+    const result = runHook(
+      {
+        tool_use: {
+          name: 'Write',
+          input: { file_path: '/etc/passwd', content: 'bad' },
+        },
+      },
+      { MULTICLAUDE_WORKTREE: worktree },
+    )
+    expect(result.exitCode).toBe(2)
+  })
+
+  it('allows nested tool_use format inside worktree', () => {
+    const result = runHook(
+      {
+        tool_use: {
+          name: 'Write',
+          input: { file_path: join(worktree, 'ok.ts'), content: '' },
+        },
+      },
+      { MULTICLAUDE_WORKTREE: worktree },
+    )
+    expect(result.exitCode).toBe(0)
+  })
+
+  // argv fallback -------------------------------------------------------------
+
+  it('accepts worktree root via argv when env var is absent', () => {
+    const hookPath = resolve(
+      new URL('../../src/spawner/worktree-guard-hook.ts', import.meta.url).pathname,
+    )
+    const payload = JSON.stringify({
+      tool_name: 'Write',
+      tool_input: { file_path: '/etc/passwd', content: 'bad' },
+    })
+    try {
+      execSync(`echo '${payload.replace(/'/g, "'\\''")}' | npx tsx ${hookPath} ${worktree}`, {
+        encoding: 'utf-8',
+        env: { ...process.env },
+        timeout: 10000,
+      })
+      // If we get here the hook allowed it — fail
+      expect(true).toBe(false)
+    } catch (err: unknown) {
+      const e = err as { status?: number }
+      expect(e.status).toBe(2)
+    }
+  })
+})

--- a/tests/tools/worker.test.ts
+++ b/tests/tools/worker.test.ts
@@ -27,6 +27,27 @@ describe('worker tools', () => {
     expect(result.title).toBe('JWT auth')
   })
 
+  it('get_my_task includes worktree_path in the response', () => {
+    updateTask(db, 'task-1', { worktree_path: '/tmp/mc-task-1-abc' })
+    const result = handleGetMyTask(db, 'w-1')
+    expect(result.worktree_path).toBe('/tmp/mc-task-1-abc')
+  })
+
+  it('get_my_task does not expose repo_path', () => {
+    updateTask(db, 'task-1', { repo_path: '/Users/marcus/Developer/MyProject' })
+    const result = handleGetMyTask(db, 'w-1')
+    expect('repo_path' in result).toBe(false)
+  })
+
+  it('get_my_task does not expose any path outside the worktree', () => {
+    const mainRepoPath = '/Users/marcus/Developer/MyProject'
+    updateTask(db, 'task-1', { repo_path: mainRepoPath, worktree_path: '/tmp/mc-task-1-abc' })
+    const result = handleGetMyTask(db, 'w-1')
+    const json = JSON.stringify(result)
+    expect(json).not.toContain(mainRepoPath)
+    expect(result.worktree_path).toBe('/tmp/mc-task-1-abc')
+  })
+
   it('report_progress writes a log entry', () => {
     handleReportProgress(db, 'w-1', 'task-1', 'running tests')
     const log = db.prepare('SELECT * FROM logs WHERE task_id = ?').get('task-1') as { message: string }


### PR DESCRIPTION
Workers could read and write files in the user's main checkout instead of their assigned worktree. The git-level isolation from #96 constrained git commands only — file tools accepted any absolute path, and every worker was handed the main checkout's path in its task payload.

## Tasks included

- **scope-task-context**: `handleGetMyTask` now returns an explicit field allowlist instead of the raw task row, so `repo_path` (the user's main checkout) is no longer given to workers.
- **boundary-guard-module**: New worktree-boundary guard — a predicate that resolves whether a candidate path lies inside a given worktree (handling `..` traversal, symlinks, not-yet-existing paths, and case-insensitive filesystems, denying by default when unclear), plus a PreToolUse hook entrypoint that reads the hook payload on stdin, denies out-of-boundary Write/Edit/Read/NotebookEdit, and records the attempt.
- **wire-guard-into-spawner**: Blanket `Write(*)` / `Edit(*)` permissions replaced with worktree-scoped rules plus deny rules for the parent repo path, and the boundary guard registered as a PreToolUse hook in each worker's `.claude/settings.local.json`. Applied across the process, cursor, and tmux runtimes. Denied attempts are recorded against the task so they surface through the normal status tools.
- **boundary-e2e-test**: End-to-end test asserting a run leaves the main checkout byte-identical with `git status` unchanged, that out-of-worktree attempts are denied, and that denials are recorded — including a regression case for two paths differing only by directory (`app/_layout.tsx` vs `app/(tabs)/_layout.tsx`) so a basename-only guard fails.
- **document-boundary-v2**: `prompts/worker.md` and the repo `CLAUDE.md` updated to describe the boundary as enforced rather than advisory, and where violations surface.

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)