### PR TITLE
fix: mergeWorktreeBranch no longer crashes on a removed worktree or loops on an already-merged branch

### DIFF
--- a/src/git/merge.ts
+++ b/src/git/merge.ts
@@ -1,5 +1,5 @@
 import { simpleGit } from 'simple-git'
-import { mkdtempSync } from 'fs'
+import { mkdtempSync, existsSync } from 'fs'
 import { rm } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join, basename } from 'path'
@@ -128,7 +128,7 @@ export async function mergeWorktreeBranch(
   branch: string,
   runId?: string,
   taskWorktreePath?: string,
-): Promise<{ push: PushResult }> {
+): Promise<{ push: PushResult; alreadyMerged?: true }> {
   const key = getIntegBranch(runId)
   const prev = mergeLocks.get(key) ?? Promise.resolve()
   let resolve!: () => void
@@ -140,10 +140,39 @@ export async function mergeWorktreeBranch(
     const git = simpleGit(repoPath)
     const integBranch = key
 
+    // SHORT-CIRCUIT: if the task branch is already an ancestor of the integration
+    // branch, the merge already landed — nothing to do. isMergedInto is robust to
+    // deleted local branches (falls back to origin/<branch>).
+    const alreadyMerged = await isMergedInto(repoPath, branch, integBranch)
+    if (alreadyMerged) {
+      return {
+        push: { ok: false, reason: 'already_merged', detail: `${branch} is already an ancestor of ${integBranch}` },
+        alreadyMerged: true,
+      }
+    }
+
+    // BRANCH-GONE: if the branch no longer exists locally or on origin, there is
+    // nothing left to merge. removeWorktree deletes the local branch with git branch -D;
+    // if the branch was never pushed, isMergedInto above would return false. Treat a
+    // fully-absent branch as a successful no-op rather than an error to break livelocks
+    // caused by retries after successful conflict-resolution cleanup.
+    let branchResolvable = false
+    for (const ref of [branch, `origin/${branch}`]) {
+      try { await git.revparse([ref]); branchResolvable = true; break } catch {}
+    }
+    if (!branchResolvable) {
+      return {
+        push: { ok: false, reason: 'already_merged', detail: `${branch} no longer exists locally or on origin` },
+        alreadyMerged: true,
+      }
+    }
+
     // Step 1: Bring task branch up to date with integration branch.
     // Merges the integration branch into the task branch so it integrates
     // against the latest state rather than a stale base.
-    if (taskWorktreePath) {
+    // This step is an optimisation — skip it when the worktree directory has been
+    // removed (e.g. cleaned up after a prior successful merge) rather than throwing.
+    if (taskWorktreePath && existsSync(taskWorktreePath)) {
       const upToDate = await isAncestorOf(git, integBranch, branch)
       if (!upToDate) {
         const taskGit = simpleGit(taskWorktreePath)

--- a/src/git/ops.ts
+++ b/src/git/ops.ts
@@ -1,6 +1,6 @@
 import { simpleGit } from 'simple-git'
 
-export type PushFailureReason = 'no_remote' | 'auth_failed' | 'non_fast_forward' | 'branch_missing' | 'push_failed'
+export type PushFailureReason = 'no_remote' | 'auth_failed' | 'non_fast_forward' | 'branch_missing' | 'push_failed' | 'already_merged'
 
 export type PushResult =
   | { ok: true; remoteBranch: string }

--- a/src/server/tools/worker.ts
+++ b/src/server/tools/worker.ts
@@ -120,13 +120,19 @@ export async function handleReportDone(
         await ensureIntegrationBranch(projectCwd, runId)
         const mergeResult = await mergeWorktreeBranch(projectCwd, task.branch, runId, task.worktree_path)
         mergedIntoRun = true
-        db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
-          taskId, 'info', `Merged ${task.branch} into ${integBranch}`
-        )
-        if (!mergeResult.push.ok) {
+        if (mergeResult.alreadyMerged) {
           db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
-            taskId, 'warn', `push_failed: ${mergeResult.push.reason}: ${mergeResult.push.detail}`
+            taskId, 'info', `Branch ${task.branch} already merged into ${integBranch} — no-op`
           )
+        } else {
+          db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
+            taskId, 'info', `Merged ${task.branch} into ${integBranch}`
+          )
+          if (!mergeResult.push.ok) {
+            db.prepare('INSERT INTO logs (task_id, level, message) VALUES (?, ?, ?)').run(
+              taskId, 'warn', `push_failed: ${mergeResult.push.reason}: ${mergeResult.push.detail}`
+            )
+          }
         }
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err)

--- a/tests/git/merge.test.ts
+++ b/tests/git/merge.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { ensureIntegrationBranch, mergeWorktreeBranch, RUN_INTEGRATION_BRANCH, MergeConflictError } from '../../src/git/merge.js'
 import { createWorktree, removeWorktree } from '../../src/git/worktree.js'
 import { execSync } from 'child_process'
-import { writeFileSync, existsSync } from 'fs'
+import { writeFileSync, existsSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { useTempDir } from '../helpers/temp.js'
@@ -227,5 +227,96 @@ describe('mergeWorktreeBranch temp dir cleanup', () => {
     expect(leaked).toHaveLength(0)
 
     await removeWorktree(repoPath, info)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Regression: mergeWorktreeBranch must tolerate a removed worktree and no-op
+// when the branch is already merged. Covers the livelock observed in run d3c5ad3d.
+// ---------------------------------------------------------------------------
+
+describe('mergeWorktreeBranch robustness — missing worktree and already-merged', () => {
+  const tmp = useTempDir()
+  let repoPath: string
+
+  beforeEach(() => {
+    repoPath = tmp.repo('mc-merge-robust-')
+  })
+
+  it('(a) succeeds when taskWorktreePath directory has been deleted — step 1 is skipped, step 2 runs', async () => {
+    const runId = 'robust-a'
+    await ensureIntegrationBranch(repoPath, runId)
+    const info = await createWorktree(repoPath, 'task-robust-a')
+    tmp.trackWorktree(info, repoPath)
+
+    writeFileSync(join(info.path, 'feature-a.ts'), 'export const a = 1')
+    execSync('git add . && git commit -m "add feature-a"', { cwd: info.path })
+
+    // Delete the worktree directory but keep the branch
+    rmSync(info.path, { recursive: true, force: true })
+    expect(existsSync(info.path)).toBe(false)
+
+    // The branch still exists — the merge must proceed via Step 2 (not throw on Step 1)
+    await expect(mergeWorktreeBranch(repoPath, info.branch, runId, info.path))
+      .resolves.not.toThrow()
+
+    // Verify the branch landed on the integration branch
+    const result = execSync(
+      `git merge-base --is-ancestor ${info.branch} mc/run-${runId} && echo yes || echo no`,
+      { cwd: repoPath }
+    ).toString().trim()
+    expect(result).toBe('yes')
+  })
+
+  it('(b) is a successful no-op when the task branch is already an ancestor of the integration branch', async () => {
+    const runId = 'robust-b'
+    await ensureIntegrationBranch(repoPath, runId)
+    const info = await createWorktree(repoPath, 'task-robust-b')
+    tmp.trackWorktree(info, repoPath)
+
+    writeFileSync(join(info.path, 'feature-b.ts'), 'export const b = 2')
+    execSync('git add . && git commit -m "add feature-b"', { cwd: info.path })
+
+    // First merge — succeeds normally
+    await mergeWorktreeBranch(repoPath, info.branch, runId)
+
+    // Capture integration branch HEAD after the first merge (before the no-op call)
+    const headBeforeNoOp = execSync(`git rev-parse mc/run-${runId}`, { cwd: repoPath }).toString().trim()
+
+    // Second merge — branch is already in the integration branch; must be a no-op
+    const result = await mergeWorktreeBranch(repoPath, info.branch, runId)
+    expect(result.alreadyMerged).toBe(true)
+    expect(result.push.ok).toBe(false)
+
+    // Integration branch must be unchanged (no spurious extra merge commit)
+    const headAfterNoOp = execSync(`git rev-parse mc/run-${runId}`, { cwd: repoPath }).toString().trim()
+    expect(headAfterNoOp).toBe(headBeforeNoOp)
+
+    await removeWorktree(repoPath, info)
+  })
+
+  it('(c) is a successful no-op when the task branch has been deleted entirely — exact livelock from run d3c5ad3d', async () => {
+    const runId = 'robust-c'
+    await ensureIntegrationBranch(repoPath, runId)
+    const info = await createWorktree(repoPath, 'task-robust-c')
+    tmp.trackWorktree(info, repoPath)
+
+    writeFileSync(join(info.path, 'feature-c.ts'), 'export const c = 3')
+    execSync('git add . && git commit -m "add feature-c"', { cwd: info.path })
+
+    // First merge — succeeds
+    await mergeWorktreeBranch(repoPath, info.branch, runId)
+
+    // Simulate removeWorktree: delete the worktree directory and branch (git branch -D)
+    await removeWorktree(repoPath, info)
+
+    // Confirm the branch is completely gone (local + never pushed = not on origin)
+    const localBranches = execSync('git branch', { cwd: repoPath }).toString()
+    expect(localBranches).not.toContain(info.branch)
+
+    // Second merge attempt — branch is gone; must return no-op without throwing
+    const result = await mergeWorktreeBranch(repoPath, info.branch, runId, info.path)
+    expect(result.alreadyMerged).toBe(true)
+    expect(result.push.ok).toBe(false)
   })
 })


### PR DESCRIPTION
## Tasks included
- **merge-missing-worktree-guard**: Fixed mergeWorktreeBranch in src/git/merge.ts to break the livelock from run d3c5ad3d. Three guards added: (1) SHORT-CIRCUIT — check isMergedInto() before any work; return alreadyMerged:true no-op when branch is already an ancestor of the integration branch. (2) BRANCH-GONE — if branch doesn't resolve locally or on origin (deleted by removeWorktree + never pushed), return the same no-op. (3) WORKTREE-DIR — wrap simpleGit(taskWorktreePath) in existsSync() so Step 1 is silently skipped when the dir is gone. Also added 'already_merged' to PushFailureReason in ops.ts, updated handleReportDone in worker.ts to log a distinct no-op message instead of a spurious push warning. Three regression tests added: (a) worktree dir deleted, branch still exists; (b) branch already in integration; (c) branch deleted entirely. Baseline: 48 files / 732 tests → After: 48 files / 735 tests, all green.

closes merge-robustness